### PR TITLE
Restrict Treesitter highlighting to specific filetypes

### DIFF
--- a/config/nvim/lua/my/mini.lua
+++ b/config/nvim/lua/my/mini.lua
@@ -255,9 +255,21 @@ later(function()
   require('nvim-treesitter').install({ 'lua', 'vim', 'tsx', 'go', 'typescript', 'html', 'markdown', 'markdown_inline',
     'bash' })
 
-  -- 全てのファイルタイプでハイライト有効化
+  -- 特定のファイルタイプでのみハイライト有効化
+  local filetypes = {
+    'lua',
+    'vim',
+    'typescriptreact', -- tsx
+    'go',
+    'typescript',
+    'html',
+    'markdown',
+    'sh',
+    'bash',
+  }
+
   vim.api.nvim_create_autocmd('FileType', {
-    pattern = '*',
+    pattern = filetypes,
     callback = function()
       pcall(vim.treesitter.start)
     end,


### PR DESCRIPTION
## Summary
Changed Treesitter syntax highlighting from being enabled for all filetypes to only specific supported filetypes. This improves performance and prevents potential issues with unsupported file types.

## Changes
- Replaced wildcard pattern (`'*'`) with an explicit list of supported filetypes in the FileType autocmd
- Added a `filetypes` table containing all languages with installed Treesitter parsers: lua, vim, typescriptreact, go, typescript, html, markdown, sh, and bash
- Updated the autocmd pattern to use this whitelist instead of matching all files

## Benefits
- **Performance**: Treesitter highlighting only starts for files where parsers are available
- **Stability**: Prevents unnecessary parser initialization attempts on unsupported filetypes
- **Maintainability**: Explicit list makes it clear which languages have Treesitter support enabled