### PR TITLE
refactor: init.luaの設定を各モジュールに分散

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,80 +1,5 @@
 vim.loader.enable()
 
--- editor options
-vim.opt.number = true
-vim.cmd('syntax enable')
-vim.opt.clipboard:append('unnamedplus,unnamed')
-vim.opt.expandtab = true
-vim.opt.shiftround = true
-vim.opt.shiftwidth = 2
-vim.opt.softtabstop = 2
-vim.opt.tabstop = 2
-vim.opt.scrolloff = 3
-vim.opt.whichwrap = 'b,s,h,l,<,>,[,],~'
-vim.opt.inccommand = "split"
-vim.opt.autoread = true
-
--- IME auto-off
-vim.api.nvim_create_autocmd("InsertLeave", {
-  pattern = "*",
-  callback = function()
-    vim.fn.system("im-select com.apple.keylayout.ABC")
-  end,
-})
-
-vim.keymap.set('t', '<Esc><Esc>', [[<C-\><C-n>]], { noremap = true })
-vim.api.nvim_create_user_command(
-  'InitLua',
-  function()
-    vim.cmd.edit(vim.fn.stdpath('config') .. '/init.lua')
-  end,
-  { desc = 'Open init.lua' }
-)
-
--- use rg for external-grep
-vim.opt.grepprg = table.concat({
-  'rg',
-  '--vimgrep',
-  '--trim',
-  '--hidden',
-  [[--glob='!.git']],
-  [[--glob='!*.lock']],
-  [[--glob='!*-lock.json']],
-  [[--glob='!*generated*']],
-}, ' ')
-vim.opt.grepformat = '%f:%l:%c:%m'
-
--- ref: `:NewGrep` in `:help grep`
-vim.api.nvim_create_user_command('Grep', function(arg)
-  local grep_cmd = 'silent grep! '
-      .. (arg.bang and '--fixed-strings -- ' or '')
-      .. vim.fn.shellescape(arg.args, true)
-  vim.cmd(grep_cmd)
-  if vim.fn.getqflist({ size = true }).size > 0 then
-    vim.cmd.copen()
-  else
-    vim.notify('no matches found', vim.log.levels.WARN)
-    vim.cmd.cclose()
-  end
-end, { nargs = '+', bang = true, desc = 'Enhounced grep' })
-
-vim.keymap.set('n', '<space>/', ':Grep ', { desc = 'Grep' })
-vim.keymap.set('n', '<space>?', ':Grep <c-r><c-w>', { desc = 'Grep current word' })
-
--- 一括置換 :s<Space>
-vim.keymap.set('ca', 's', function()
-  if vim.fn.getcmdtype() == ':' and vim.fn.getcmdline() == 's' then
-    return '%s///g<Left><Left><Left>'
-  end
-  return 's'
-end, { expr = true })
-
--- leader + Code Action で呼び出し
-vim.keymap.set('n', '<space>w', vim.lsp.buf.code_action, { desc = "LSP code action" })
-
--- /検索のハイライトを消す
-vim.keymap.set('n', '<Esc><Esc>', '<cmd>nohlsearch<CR>', { silent = true })
-
 -- Clone 'mini.nvim' manually in a way that it gets managed by 'mini.deps'
 local path_package = vim.fn.stdpath('data') .. '/site/'
 local mini_path = path_package .. 'pack/deps/start/mini.nvim'
@@ -88,12 +13,6 @@ if not vim.uv.fs_stat(mini_path) then
   vim.cmd('packadd mini.nvim | helptags ALL')
   vim.cmd('echo "Installed `mini.nvim`" | redraw')
 end
-
-vim.api.nvim_create_user_command('CopyPath', function()
-  local path = vim.fn.expand('%')
-  vim.fn.setreg('+', path)
-  print("Copied: " .. path)
-end, {})
 
 -- Set up 'mini.deps' (customize to your liking)
 require('mini.deps').setup({ path = { package = path_package } })

--- a/config/nvim/lua/editor.lua
+++ b/config/nvim/lua/editor.lua
@@ -1,5 +1,71 @@
 -- 操作系
 
+-- editor options
+vim.opt.number = true
+vim.cmd('syntax enable')
+vim.opt.clipboard:append('unnamedplus,unnamed')
+vim.opt.expandtab = true
+vim.opt.shiftround = true
+vim.opt.shiftwidth = 2
+vim.opt.softtabstop = 2
+vim.opt.tabstop = 2
+vim.opt.scrolloff = 3
+vim.opt.whichwrap = 'b,s,h,l,<,>,[,],~'
+vim.opt.inccommand = "split"
+vim.opt.autoread = true
+
+-- IME auto-off
+vim.api.nvim_create_autocmd("InsertLeave", {
+  pattern = "*",
+  callback = function()
+    vim.fn.system("im-select com.apple.keylayout.ABC")
+  end,
+})
+
+vim.api.nvim_create_user_command(
+  'InitLua',
+  function()
+    vim.cmd.edit(vim.fn.stdpath('config') .. '/init.lua')
+  end,
+  { desc = 'Open init.lua' }
+)
+
+-- use rg for external-grep
+vim.opt.grepprg = table.concat({
+  'rg',
+  '--vimgrep',
+  '--trim',
+  '--hidden',
+  [[--glob='!.git']],
+  [[--glob='!*.lock']],
+  [[--glob='!*-lock.json']],
+  [[--glob='!*generated*']],
+}, ' ')
+vim.opt.grepformat = '%f:%l:%c:%m'
+
+-- ref: `:NewGrep` in `:help grep`
+vim.api.nvim_create_user_command('Grep', function(arg)
+  local grep_cmd = 'silent grep! '
+      .. (arg.bang and '--fixed-strings -- ' or '')
+      .. vim.fn.shellescape(arg.args, true)
+  vim.cmd(grep_cmd)
+  if vim.fn.getqflist({ size = true }).size > 0 then
+    vim.cmd.copen()
+  else
+    vim.notify('no matches found', vim.log.levels.WARN)
+    vim.cmd.cclose()
+  end
+end, { nargs = '+', bang = true, desc = 'Enhounced grep' })
+
+vim.keymap.set('n', '<space>/', ':Grep ', { desc = 'Grep' })
+vim.keymap.set('n', '<space>?', ':Grep <c-r><c-w>', { desc = 'Grep current word' })
+
+vim.api.nvim_create_user_command('CopyPath', function()
+  local path = vim.fn.expand('%')
+  vim.fn.setreg('+', path)
+  print("Copied: " .. path)
+end, {})
+
 -- treesitter
 MiniDeps.now(function()
   MiniDeps.add({

--- a/config/nvim/lua/keybind.lua
+++ b/config/nvim/lua/keybind.lua
@@ -1,5 +1,18 @@
 -- キーバインド系
 
+vim.keymap.set('t', '<Esc><Esc>', [[<C-\><C-n>]], { noremap = true })
+
+-- 一括置換 :s<Space>
+vim.keymap.set('ca', 's', function()
+  if vim.fn.getcmdtype() == ':' and vim.fn.getcmdline() == 's' then
+    return '%s///g<Left><Left><Left>'
+  end
+  return 's'
+end, { expr = true })
+
+-- /検索のハイライトを消す
+vim.keymap.set('n', '<Esc><Esc>', '<cmd>nohlsearch<CR>', { silent = true })
+
 -- clue (全体のキーバインドヒント)
 MiniDeps.later(function()
   local function mode_nx(keys)

--- a/config/nvim/lua/lsp/init.lua
+++ b/config/nvim/lua/lsp/init.lua
@@ -22,6 +22,9 @@ vim.api.nvim_create_autocmd('LspAttach', {
     vim.keymap.set('n', '<M-f>', function()
       vim.lsp.buf.format({ bufnr = args.buf })
     end, { buffer = args.buf, desc = 'Format buffer' })
+
+    vim.keymap.set('n', '<space>w', vim.lsp.buf.code_action,
+      { buffer = args.buf, desc = 'LSP code action' })
   end,
 })
 


### PR DESCRIPTION
- editor.lua: vim.opt設定、IME auto-off、InitLuaコマンド、rg/Grepコマンド+キーマップ、CopyPathコマンドを移動
- keybind.lua: ターミナルエスケープ、一括置換、nohlsearchキーマップを移動
- lsp/init.lua: <space>w code actionキーマップをLspAttach内にbuffer-localで移動
- init.lua: mini.nvimブートストラップとrequire群のみ残す

https://claude.ai/code/session_0175SqSmjMDdb92dy9bUm4EU