### PR TITLE
chore: mainの内容をfor-businessに取り込む

### DIFF
--- a/config/nvim/lua/appearance.lua
+++ b/config/nvim/lua/appearance.lua
@@ -2,9 +2,11 @@
 
 vim.o.winbar = " %m %f "
 
+local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
+
 -- colorscheme
-MiniDeps.now(function()
-  MiniDeps.add({ source = 'https://github.com/folke/tokyonight.nvim' })
+now(function()
+  add({ source = 'https://github.com/folke/tokyonight.nvim' })
   require("tokyonight").setup({
     style = "storm",
     transparent = true,
@@ -22,30 +24,30 @@ MiniDeps.now(function()
   vim.cmd.colorscheme('tokyonight')
 end)
 
-MiniDeps.later(function()
-  MiniDeps.add('https://github.com/vim-jp/vimdoc-ja')
+later(function()
+  add('https://github.com/vim-jp/vimdoc-ja')
   vim.opt.helplang:prepend('ja')
 end)
 
 -- Simple plugins
-MiniDeps.now(require('mini.icons').setup)
-MiniDeps.later(require('mini.indentscope').setup)
+now(require('mini.icons').setup)
+later(require('mini.indentscope').setup)
 
 -- statusline
-MiniDeps.now(function()
+now(function()
   require('mini.statusline').setup()
   vim.opt.laststatus = 3
   vim.opt.cmdheight = 0
 end)
 
 -- notify
-MiniDeps.now(function()
+now(function()
   require('mini.notify').setup()
   vim.notify = require('mini.notify').make_notify({})
 end)
 
 -- hipatterns
-MiniDeps.later(function()
+later(function()
   local hipatterns = require('mini.hipatterns')
   local hi_words = require('mini.extra').gen_highlighter.words
   hipatterns.setup({
@@ -59,7 +61,7 @@ MiniDeps.later(function()
 end)
 
 -- trailspace
-MiniDeps.later(function()
+later(function()
   require('mini.trailspace').setup()
   vim.api.nvim_create_user_command(
     'Trim',
@@ -72,7 +74,7 @@ MiniDeps.later(function()
 end)
 
 -- clue (全体のキーバインドヒント)
-MiniDeps.later(function()
+later(function()
   local function mode_nx(keys)
     return { mode = 'n', keys = keys }, { mode = 'x', keys = keys }
   end

--- a/config/nvim/lua/completion.lua
+++ b/config/nvim/lua/completion.lua
@@ -1,5 +1,7 @@
 -- 補完系
 
+local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
+
 -- snippets
 local gen_loader = require('mini.snippets').gen_loader
 require('mini.snippets').setup({
@@ -13,7 +15,7 @@ require('mini.snippets').setup({
 MiniSnippets.start_lsp_server()
 
 -- completion
-MiniDeps.later(function()
+later(function()
   require('mini.fuzzy').setup()
   require('mini.completion').setup({
     lsp_completion = {

--- a/config/nvim/lua/edit.lua
+++ b/config/nvim/lua/edit.lua
@@ -66,9 +66,11 @@ vim.api.nvim_create_user_command('CopyPath', function()
   print("Copied: " .. path)
 end, {})
 
+local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
+
 -- treesitter
-MiniDeps.now(function()
-  MiniDeps.add({
+now(function()
+  add({
     source = 'https://github.com/nvim-treesitter/nvim-treesitter',
     hooks = {
       post_checkout = function()
@@ -92,8 +94,8 @@ MiniDeps.now(function()
   require('nvim-treesitter.install').update({ with_sync = true })
 end)
 
-MiniDeps.later(function()
-  MiniDeps.add({
+later(function()
+  add({
     source = 'https://github.com/folke/ts-comments.nvim',
     depends = { 'nvim-treesitter/nvim-treesitter' },
   })
@@ -106,8 +108,8 @@ vim.opt.foldlevel = 99
 
 -- Simple plugins
 for _, name in ipairs({ 'pairs', 'surround', 'move', 'bracketed', 'jump2d' }) do
-  MiniDeps.later(require('mini.' .. name).setup)
+  later(require('mini.' .. name).setup)
 end
 
 -- basics
-MiniDeps.now(require('mini.basics').setup)
+now(require('mini.basics').setup)

--- a/config/nvim/lua/git.lua
+++ b/config/nvim/lua/git.lua
@@ -1,6 +1,8 @@
 -- Git系
 
-MiniDeps.later(function()
+local later = MiniDeps.later
+
+later(function()
   require('mini.diff').setup()
 end)
 

--- a/config/nvim/lua/git.lua
+++ b/config/nvim/lua/git.lua
@@ -2,11 +2,9 @@
 
 local later = MiniDeps.later
 
-later(function()
-  require('mini.diff').setup()
-end)
+later(require('mini.diff').setup)
 
-MiniDeps.later(function()
+later(function()
   require('mini.git').setup()
 
   vim.keymap.set({ 'n', 'x' }, '<space>gs', MiniGit.show_at_cursor, { desc = 'Show at cursor' })

--- a/config/nvim/lua/git.lua
+++ b/config/nvim/lua/git.lua
@@ -1,6 +1,6 @@
 -- Git系
 
-local later = MiniDeps.later
+local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
 
 later(require('mini.diff').setup)
 

--- a/config/nvim/lua/lsp/init.lua
+++ b/config/nvim/lua/lsp/init.lua
@@ -1,4 +1,6 @@
 -- config of lsp
+
+local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
 vim.diagnostic.config({
   virtual_text = true,
 })
@@ -54,7 +56,7 @@ end
 
 vim.lsp.enable(lsp_names)
 
-MiniDeps.later(function()
-  MiniDeps.add("pcolladosoto/tinygo.nvim")
+later(function()
+  add("pcolladosoto/tinygo.nvim")
   require("tinygo").setup({})
 end)

--- a/config/nvim/lua/nav.lua
+++ b/config/nvim/lua/nav.lua
@@ -1,6 +1,6 @@
 -- 探索系
 
-local now = MiniDeps.now
+local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
 
 -- starter
 now(require('mini.starter').setup)
@@ -43,7 +43,7 @@ now(function()
 end)
 
 -- pick
-MiniDeps.later(function()
+later(function()
   require('mini.pick').setup()
 
   vim.ui.select = MiniPick.ui_select

--- a/config/nvim/lua/nav.lua
+++ b/config/nvim/lua/nav.lua
@@ -1,10 +1,12 @@
 -- 探索系
 
+local now = MiniDeps.now
+
 -- starter
-MiniDeps.now(require('mini.starter').setup)
+now(require('mini.starter').setup)
 
 -- misc
-MiniDeps.now(function()
+now(function()
   require('mini.misc').setup()
 
   MiniMisc.setup_restore_cursor()
@@ -15,7 +17,7 @@ MiniDeps.now(function()
 end)
 
 -- files
-MiniDeps.now(function()
+now(function()
   require('mini.files').setup()
 
   -- mini.files.setup() がハイライトを上書きするため、setup() 後に再設定


### PR DESCRIPTION
## Summary

`main` ブランチの最新コミット（#29）を `for-business` に取り込む。

## Changes

- refactor: MiniDepsのadd/now/laterをローカル変数に代入して可読性改善 (#29)

## Conflict Resolution

- `config/nvim/lua/lsp/init.lua`: `for-business` では tinygo を意図的に削除しているため、HEADの内容を採用。