### PR TITLE
refactor(nvim): clarify Lua boolean checks

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -3,7 +3,7 @@ vim.loader.enable()
 -- Clone 'mini.nvim' manually in a way that it gets managed by 'mini.deps'
 local path_package = vim.fn.stdpath('data') .. '/site/'
 local mini_path = path_package .. 'pack/deps/start/mini.nvim'
-if not vim.uv.fs_stat(mini_path) then
+if vim.uv.fs_stat(mini_path) == nil then
   vim.cmd('echo "Installing `mini.nvim`" | redraw')
   local clone_cmd = {
     'git', 'clone', '--filter=blob:none',

--- a/config/nvim/lua/completion.lua
+++ b/config/nvim/lua/completion.lua
@@ -14,6 +14,15 @@ vim.opt.completeopt = { 'menu', 'menuone', 'noselect', 'fuzzy', 'popup' }
 vim.opt.complete = { '.', 'w', 'k', 'b', 'u' }
 vim.opt.dictionary:append('/usr/share/dict/words')
 
+-- Vim API の 0/1 を素直な bool に変換するヘルパー
+local function pum_visible()
+  return vim.fn.pumvisible() == 1
+end
+
+local function in_insert_mode()
+  return vim.fn.mode() == 'i'
+end
+
 local autotrigger_group = vim.api.nvim_create_augroup('lsp/completion', {})
 local autotrigger_timer = vim.uv.new_timer()
 local autotrigger_ms = 150
@@ -34,14 +43,15 @@ vim.api.nvim_create_autocmd('LspAttach', {
       callback = function()
         autotrigger_timer:stop()
         local col = vim.api.nvim_win_get_cursor(0)[2]
-        if col == 0 then return end
-        if vim.fn.pumvisible() == 1 then return end
+        local at_line_start = col == 0
+        if at_line_start then return end
+        if pum_visible() then return end
         local prev_char = vim.api.nvim_get_current_line():sub(col, col)
         if not prev_char:match('[%w_]') then return end
         local buf = ev.buf
         autotrigger_timer:start(autotrigger_ms, 0, vim.schedule_wrap(function()
           if vim.api.nvim_get_current_buf() ~= buf then return end
-          if vim.fn.mode() ~= 'i' or vim.fn.pumvisible() ~= 0 then return end
+          if not in_insert_mode() or pum_visible() then return end
           vim.lsp.completion.get()
         end))
       end,
@@ -60,23 +70,24 @@ local keys = {
 }
 
 vim.keymap.set('i', '<tab>', function()
-  if vim.fn.pumvisible() == 1 then
+  if pum_visible() then
     return keys.cn
   end
   return keys.ct
 end, { expr = true, desc = 'Select next item if popup is visible' })
 
 vim.keymap.set('i', '<s-tab>', function()
-  if vim.fn.pumvisible() == 1 then
+  if pum_visible() then
     return keys.cp
   end
   return keys.cd
 end, { expr = true, desc = 'Select previous item if popup is visible' })
 
 vim.keymap.set('i', '<cr>', function()
-  if vim.fn.pumvisible() == 0 then
+  if not pum_visible() then
     return require('mini.pairs').cr()
   end
+  -- complete_info().selected は未選択時に -1 を返す
   local item_selected = vim.fn.complete_info()['selected'] ~= -1
   if item_selected then
     return keys.cy

--- a/config/nvim/lua/completion.lua
+++ b/config/nvim/lua/completion.lua
@@ -22,7 +22,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
   group = autotrigger_group,
   callback = function(ev)
     local client = vim.lsp.get_client_by_id(ev.data.client_id)
-    if not (client and client:supports_method('textDocument/completion')) then
+    if client == nil or not client:supports_method('textDocument/completion') then
       return
     end
     vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
@@ -60,11 +60,17 @@ local keys = {
 }
 
 vim.keymap.set('i', '<tab>', function()
-  return vim.fn.pumvisible() == 1 and keys.cn or keys.ct
+  if vim.fn.pumvisible() == 1 then
+    return keys.cn
+  end
+  return keys.ct
 end, { expr = true, desc = 'Select next item if popup is visible' })
 
 vim.keymap.set('i', '<s-tab>', function()
-  return vim.fn.pumvisible() == 1 and keys.cp or keys.cd
+  if vim.fn.pumvisible() == 1 then
+    return keys.cp
+  end
+  return keys.cd
 end, { expr = true, desc = 'Select previous item if popup is visible' })
 
 vim.keymap.set('i', '<cr>', function()

--- a/config/nvim/lua/edit.lua
+++ b/config/nvim/lua/edit.lua
@@ -45,8 +45,12 @@ vim.opt.grepformat = '%f:%l:%c:%m'
 
 -- ref: `:NewGrep` in `:help grep`
 vim.api.nvim_create_user_command('Grep', function(arg)
+  local fixed_strings_opt = ''
+  if arg.bang then
+    fixed_strings_opt = '--fixed-strings -- '
+  end
   local grep_cmd = 'silent grep! '
-      .. (arg.bang and '--fixed-strings -- ' or '')
+      .. fixed_strings_opt
       .. vim.fn.shellescape(arg.args, true)
   vim.cmd(grep_cmd)
   if vim.fn.getqflist({ size = true }).size > 0 then

--- a/config/nvim/lua/lsp/init.lua
+++ b/config/nvim/lua/lsp/init.lua
@@ -20,7 +20,7 @@ now(function()
       upward = true,
       path = search_path,
     })
-    if #found == 0 then return end
+    if vim.tbl_isempty(found) then return end
     local f = io.open(found[1], "r")
     if f == nil then return end
     local raw = f:read("a")

--- a/config/nvim/lua/lsp/init.lua
+++ b/config/nvim/lua/lsp/init.lua
@@ -12,17 +12,21 @@ now(function()
   -- 絶対パスで読み取って TinyGoSetTarget を直接呼ぶ。
   tinygo.applyConfigFile = function()
     local bufname = vim.api.nvim_buf_get_name(0)
+    local search_path = nil
+    if bufname ~= "" then
+      search_path = vim.fs.dirname(bufname)
+    end
     local found = vim.fs.find(tinygo.config_file, {
       upward = true,
-      path = bufname ~= "" and vim.fs.dirname(bufname) or nil,
+      path = search_path,
     })
     if #found == 0 then return end
     local f = io.open(found[1], "r")
-    if not f then return end
+    if f == nil then return end
     local raw = f:read("a")
     f:close()
     local ok, cfg = pcall(vim.json.decode, raw)
-    if not ok or type(cfg) ~= "table" or not cfg.target then return end
+    if not ok or type(cfg) ~= "table" or cfg.target == nil then return end
     vim.cmd.TinyGoSetTarget(cfg.target)
   end
 

--- a/config/nvim/plugin/oplog.lua
+++ b/config/nvim/plugin/oplog.lua
@@ -63,7 +63,7 @@ local function rotate_if_needed()
 end
 
 local function flush()
-  if #buf == 0 then return end
+  if vim.tbl_isempty(buf) then return end
   local lines = buf
   buf = {}
   rotate_if_needed()

--- a/config/nvim/plugin/oplog.lua
+++ b/config/nvim/plugin/oplog.lua
@@ -45,23 +45,21 @@ end
 
 local function rotate_if_needed()
   local stat = vim.uv.fs_stat(log_path)
-  if stat and stat.size > max_size then
-    local f = io.open(log_path, 'r')
-    if not f then return end
-    local content = f:read('*a')
-    f:close()
-    -- 先頭半分を切り捨てて後半を残す
-    local half = math.floor(#content / 2)
-    local newline_pos = content:find('\n', half)
-    if newline_pos then
-      content = content:sub(newline_pos + 1)
-    end
-    local wf = io.open(log_path, 'w')
-    if wf then
-      wf:write(content)
-      wf:close()
-    end
+  if stat == nil or stat.size <= max_size then return end
+  local f = io.open(log_path, 'r')
+  if f == nil then return end
+  local content = f:read('*a')
+  f:close()
+  -- 先頭半分を切り捨てて後半を残す
+  local half = math.floor(#content / 2)
+  local newline_pos = content:find('\n', half)
+  if newline_pos ~= nil then
+    content = content:sub(newline_pos + 1)
   end
+  local wf = io.open(log_path, 'w')
+  if wf == nil then return end
+  wf:write(content)
+  wf:close()
 end
 
 local function flush()
@@ -70,7 +68,7 @@ local function flush()
   buf = {}
   rotate_if_needed()
   local f = io.open(log_path, 'a')
-  if not f then return end
+  if f == nil then return end
   for _, line in ipairs(lines) do
     f:write(line .. '\n')
   end
@@ -78,11 +76,10 @@ local function flush()
 end
 
 local function cancel_timer()
-  if flush_timer then
-    flush_timer:stop()
-    flush_timer:close()
-    flush_timer = nil
-  end
+  if flush_timer == nil then return end
+  flush_timer:stop()
+  flush_timer:close()
+  flush_timer = nil
 end
 
 local function schedule_flush()


### PR DESCRIPTION
Replace `cond and X or Y` ternary idioms with explicit if/else, and
make implicit truthy/nil checks explicit with `== nil` / `~= nil` so
the intent of each branch is obvious.

https://claude.ai/code/session_0132EhQn7YhvWUzirda874UJ