### PR TITLE
refactor(makefile): switch dotfiles deployment from symlink to rsync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,6 @@
 # for macOS
 /**/.DS_store
 
-# Claude Code
-**/.claude/*
-!**/.claude/settings.json
-!**/.claude/CLAUDE.md
-!**/.claude/skills
-!**/.claude/rules
-!**/.claude/statusline.js
-
 # Copilot
 /**/ide
 /**/logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
 # for macOS
 /**/.DS_store
 
+# Claude Code
+**/.claude/*
+!**/.claude/settings.json
+!**/.claude/CLAUDE.md
+!**/.claude/skills
+!**/.claude/rules
+!**/.claude/statusline.js
+
 # Copilot
 /**/ide
 /**/logs

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-DOTFILES_DIR := $(CURDIR)
 BREW_PREFIX  := /opt/homebrew
 BREW         := $(BREW_PREFIX)/bin/brew
 
 export PATH := $(BREW_PREFIX)/bin:$(PATH)
 
-.PHONY: setup brew-install home-link brew-bundle config-link tools clean help
+RSYNC_OPTS := -av --checksum --exclude='.DS_Store' --exclude='.git'
 
-setup: brew-install home-link brew-bundle config-link tools ## Run full setup
+.PHONY: setup brew-install home-deploy brew-bundle config-deploy tools help
+
+setup: brew-install home-deploy brew-bundle config-deploy tools ## Run full setup
 
 brew-install: ## Install Homebrew (if not installed)
 	@if [ ! -f "$(BREW)" ]; then \
@@ -14,46 +15,19 @@ brew-install: ## Install Homebrew (if not installed)
 		/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; \
 	fi
 
-home-link: ## Deploy home dotfiles (./home/ -> ~/)
-	@find ./home -maxdepth 1 -mindepth 1 | while read -r src; do \
-		name=$$(basename "$$src"); \
-		ln -sfn "$(DOTFILES_DIR)/home/$$name" "$$HOME/$$name"; \
-		echo "Linked: $$name"; \
-	done
+home-deploy: ## Deploy home dotfiles (./home/ -> ~/)
+	rsync $(RSYNC_OPTS) ./home/ $$HOME/
 
 brew-bundle: ## Install packages via Homebrew (brew bundle --global)
 	brew bundle --global
 
-config-link: ## Deploy config dotfiles (./config/* -> ~/.config/)
+config-deploy: ## Deploy config dotfiles (./config/ -> ~/.config/)
 	@mkdir -p "$$HOME/.config"
-	@find ./config -maxdepth 1 -mindepth 1 | while read -r src; do \
-		name=$$(basename "$$src"); \
-		target="$$HOME/.config/$$name"; \
-		ln -sfn "$(DOTFILES_DIR)/config/$$name" "$$target"; \
-		echo "Linked: $$name"; \
-	done
+	rsync $(RSYNC_OPTS) ./config/ $$HOME/.config/
 
 tools: ## Install development tools (mise install, gopls)
 	mise install
 	mise exec -- go install golang.org/x/tools/gopls@latest
-
-clean: ## Remove created symlinks
-	@echo "Removing symlinks..."
-	@find ./home -maxdepth 1 -mindepth 1 | while read -r src; do \
-		name=$$(basename "$$src"); \
-		if [ -L "$$HOME/$$name" ]; then \
-			rm "$$HOME/$$name"; \
-			echo "Removed: $$name"; \
-		fi; \
-	done
-	@find ./config -maxdepth 1 -mindepth 1 | while read -r src; do \
-		name=$$(basename "$$src"); \
-		target="$$HOME/.config/$$name"; \
-		if [ -L "$$target" ]; then \
-			rm "$$target"; \
-			echo "Removed: $$name"; \
-		fi; \
-	done
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export PATH := $(BREW_PREFIX)/bin:$(PATH)
 
 RSYNC_OPTS := -av --checksum --exclude='.DS_Store' --exclude='.git'
 
-.PHONY: setup brew-install home-deploy brew-bundle config-deploy tools clean clean-check help
+.PHONY: setup brew-install home-deploy brew-bundle config-deploy tools clean help
 
 setup: brew-install home-deploy brew-bundle config-deploy tools ## Run full setup
 
@@ -29,43 +29,27 @@ tools: ## Install development tools (mise install, gopls)
 	mise install
 	mise exec -- go install golang.org/x/tools/gopls@latest
 
-clean-check: ## Preview files that clean would remove
-	@echo "Files to be removed from \$$HOME:"
-	@find ./home -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
-		rel="$${src#./home/}"; \
-		target="$$HOME/$$rel"; \
-		if [ -f "$$target" ]; then \
-			echo "  $$target"; \
-		fi; \
-	done
-	@echo "Files to be removed from \$$HOME/.config:"
-	@find ./config -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
-		rel="$${src#./config/}"; \
-		target="$$HOME/.config/$$rel"; \
-		if [ -f "$$target" ]; then \
-			echo "  $$target"; \
-		fi; \
-	done
-
-clean: ## Remove deployed files from ~/ and ~/.config/
-	@echo "Removing deployed files from \$$HOME..."
-	@find ./home -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
-		rel="$${src#./home/}"; \
-		target="$$HOME/$$rel"; \
-		if [ -f "$$target" ]; then \
-			rm "$$target"; \
-			echo "Removed: $$target"; \
-		fi; \
-	done
-	@echo "Removing deployed files from \$$HOME/.config..."
-	@find ./config -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
-		rel="$${src#./config/}"; \
-		target="$$HOME/.config/$$rel"; \
-		if [ -f "$$target" ]; then \
-			rm "$$target"; \
-			echo "Removed: $$target"; \
-		fi; \
-	done
+clean: ## Remove deployed files from ~/ and ~/.config/ (prompts for confirmation)
+	@files=$$( \
+		{ find ./home -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
+			rel="$${src#./home/}"; target="$$HOME/$$rel"; \
+			[ -f "$$target" ] && echo "$$target"; \
+		  done; \
+		  find ./config -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
+			rel="$${src#./config/}"; target="$$HOME/.config/$$rel"; \
+			[ -f "$$target" ] && echo "$$target"; \
+		  done; \
+		} \
+	); \
+	if [ -z "$$files" ]; then echo "No files to remove."; exit 0; fi; \
+	echo "Files to be removed:"; \
+	echo "$$files" | sed 's/^/  /'; \
+	printf "Continue? [y/N]: "; \
+	read ans; \
+	case "$$ans" in \
+		[yY]) echo "$$files" | while read -r f; do rm "$$f" && echo "Removed: $$f"; done ;; \
+		*) echo "Aborted." ;; \
+	esac
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ BREW         := $(BREW_PREFIX)/bin/brew
 
 export PATH := $(BREW_PREFIX)/bin:$(PATH)
 
-RSYNC_OPTS := -av --checksum --exclude='.DS_Store' --exclude='.git'
+FIND_EXCLUDES := ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*'
+RSYNC_OPTS    := -av --checksum --exclude='.DS_Store' --exclude='.git'
 
 .PHONY: setup brew-install home-deploy brew-bundle config-deploy tools clean help
 
@@ -30,24 +31,21 @@ tools: ## Install development tools (mise install, gopls)
 	mise exec -- go install golang.org/x/tools/gopls@latest
 
 clean: ## Remove deployed files from ~/ and ~/.config/ (prompts for confirmation)
-	@files=$$( \
-		{ find ./home -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
-			rel="$${src#./home/}"; target="$$HOME/$$rel"; \
+	@list() { \
+		src_dir="$$1"; dest_dir="$$2"; \
+		find "$$src_dir" -type f $(FIND_EXCLUDES) | while read -r src; do \
+			rel="$${src#$$src_dir/}"; target="$$dest_dir/$$rel"; \
 			[ -f "$$target" ] && echo "$$target"; \
-		  done; \
-		  find ./config -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
-			rel="$${src#./config/}"; target="$$HOME/.config/$$rel"; \
-			[ -f "$$target" ] && echo "$$target"; \
-		  done; \
-		} \
-	); \
+		done; \
+	}; \
+	files=$$( { list ./home $$HOME; list ./config $$HOME/.config; } ); \
 	if [ -z "$$files" ]; then echo "No files to remove."; exit 0; fi; \
 	echo "Files to be removed:"; \
 	echo "$$files" | sed 's/^/  /'; \
 	printf "Continue? [y/N]: "; \
 	read ans; \
 	case "$$ans" in \
-		[yY]) echo "$$files" | while read -r f; do rm "$$f" && echo "Removed: $$f"; done ;; \
+		[yY]|[yY][eE][sS]) echo "$$files" | while read -r f; do rm "$$f" && echo "Removed: $$f"; done ;; \
 		*) echo "Aborted." ;; \
 	esac
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export PATH := $(BREW_PREFIX)/bin:$(PATH)
 
 RSYNC_OPTS := -av --checksum --exclude='.DS_Store' --exclude='.git'
 
-.PHONY: setup brew-install home-deploy brew-bundle config-deploy tools help
+.PHONY: setup brew-install home-deploy brew-bundle config-deploy tools clean help
 
 setup: brew-install home-deploy brew-bundle config-deploy tools ## Run full setup
 
@@ -28,6 +28,26 @@ config-deploy: ## Deploy config dotfiles (./config/ -> ~/.config/)
 tools: ## Install development tools (mise install, gopls)
 	mise install
 	mise exec -- go install golang.org/x/tools/gopls@latest
+
+clean: ## Remove deployed files from ~/ and ~/.config/
+	@echo "Removing deployed files from \$$HOME..."
+	@find ./home -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
+		rel="$${src#./home/}"; \
+		target="$$HOME/$$rel"; \
+		if [ -f "$$target" ]; then \
+			rm "$$target"; \
+			echo "Removed: $$target"; \
+		fi; \
+	done
+	@echo "Removing deployed files from \$$HOME/.config..."
+	@find ./config -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
+		rel="$${src#./config/}"; \
+		target="$$HOME/.config/$$rel"; \
+		if [ -f "$$target" ]; then \
+			rm "$$target"; \
+			echo "Removed: $$target"; \
+		fi; \
+	done
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export PATH := $(BREW_PREFIX)/bin:$(PATH)
 
 RSYNC_OPTS := -av --checksum --exclude='.DS_Store' --exclude='.git'
 
-.PHONY: setup brew-install home-deploy brew-bundle config-deploy tools clean help
+.PHONY: setup brew-install home-deploy brew-bundle config-deploy tools clean clean-check help
 
 setup: brew-install home-deploy brew-bundle config-deploy tools ## Run full setup
 
@@ -28,6 +28,24 @@ config-deploy: ## Deploy config dotfiles (./config/ -> ~/.config/)
 tools: ## Install development tools (mise install, gopls)
 	mise install
 	mise exec -- go install golang.org/x/tools/gopls@latest
+
+clean-check: ## Preview files that clean would remove
+	@echo "Files to be removed from \$$HOME:"
+	@find ./home -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
+		rel="$${src#./home/}"; \
+		target="$$HOME/$$rel"; \
+		if [ -f "$$target" ]; then \
+			echo "  $$target"; \
+		fi; \
+	done
+	@echo "Files to be removed from \$$HOME/.config:"
+	@find ./config -type f ! -name '.DS_Store' ! -name '.git' ! -path '*/.git/*' | while read -r src; do \
+		rel="$${src#./config/}"; \
+		target="$$HOME/.config/$$rel"; \
+		if [ -f "$$target" ]; then \
+			echo "  $$target"; \
+		fi; \
+	done
 
 clean: ## Remove deployed files from ~/ and ~/.config/
 	@echo "Removing deployed files from \$$HOME..."

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ make home-deploy    # home dotfiles only
 make brew-bundle    # brew bundle only
 make config-deploy  # config dotfiles only
 make tools          # tool installation only
-make clean-check    # preview files that clean would remove
-make clean          # remove deployed files
+make clean          # remove deployed files (prompts for confirmation)
 ```
 
 ## Structure

--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ This will:
 ### Individual Targets
 
 ```bash
-make brew-install  # Install Homebrew
-make home-link     # home dotfiles only
-make brew-bundle   # brew bundle only
-make config-link   # config dotfiles only
-make tools         # tool installation only
-make clean         # remove created symlinks
+make brew-install   # Install Homebrew
+make home-deploy    # home dotfiles only
+make brew-bundle    # brew bundle only
+make config-deploy  # config dotfiles only
+make tools          # tool installation only
 ```
 
 ## Structure

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ make home-deploy    # home dotfiles only
 make brew-bundle    # brew bundle only
 make config-deploy  # config dotfiles only
 make tools          # tool installation only
+make clean-check    # preview files that clean would remove
 make clean          # remove deployed files
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ make home-deploy    # home dotfiles only
 make brew-bundle    # brew bundle only
 make config-deploy  # config dotfiles only
 make tools          # tool installation only
+make clean          # remove deployed files
 ```
 
 ## Structure


### PR DESCRIPTION
symlink-based deploy has two problems:
- directory-level symlinks cause tool runtime files to pollute the repo
  (worked around with .gitignore allowlist)
- file-level symlinks would require re-running make when new files are
  added (e.g. new claude skills)

switch to rsync-based one-way deploy (repo -> ~/). files in ~/ become
real files, so tools writing to ~/.claude/ etc. no longer affect the
repo. the .gitignore allowlist hack is no longer needed.

- home-link -> home-deploy (rsync)
- config-link -> config-deploy (rsync)
- clean target dropped (no symlinks to clean)