### PR TITLE
fix(nvim): drop toggleterm open_mapping to avoid ciw conflict

### DIFF
--- a/config/nvim/lua/terminal.lua
+++ b/config/nvim/lua/terminal.lua
@@ -6,7 +6,8 @@ vim.pack.add({ 'https://github.com/akinsho/toggleterm.nvim' })
 
 later(function()
   require('toggleterm').setup({
-    open_mapping = [[<C-\>]],
+    -- `open_mapping` を <C-\> に設定すると ciw など operator-pending の
+    -- キーシーケンスに割り込むため未設定。<leader>th/tv/tf や <leader>1..5 を使う。
     direction = 'horizontal',
     size = function(term)
       if term.direction == 'horizontal' then


### PR DESCRIPTION
## Summary
- `open_mapping = [[<C-\>]]` を削除し、`ciw` などの operator-pending シーケンスと衝突する問題を解消
- ターミナル起動は既存の `<leader>th` / `<leader>tv` / `<leader>tf` と `<leader>1`..`<leader>5` で代替可能

## Background
`<C-\>` は Neovim 内部で `<C-\><C-n>` のような複数キーシーケンスのプレフィックスとして使われており、これを `open_mapping` に設定すると normal/operator-pending モードのキー処理に干渉する。結果として `ciw`（change inner word）など Vim の標準操作の入力中にトグルタームが発動してしまう。

## Test plan
- [ ] `nvim` を起動し、適当な単語上で `ciw` を実行 → ターミナルが起動せず word が削除されて insert モードに入る
- [ ] `<leader>th` / `<leader>tv` / `<leader>tf` でそれぞれの方向のターミナルが開く
- [ ] `<leader>1` 〜 `<leader>5` で番号付きターミナルが切り替わる
- [ ] `<leader>lg` / `<leader>ld` で lazygit / lazydocker が開く

https://claude.ai/code/session_019mnk19otpr7uYCWB7YTaVr

---
_Generated by [Claude Code](https://claude.ai/code/session_019mnk19otpr7uYCWB7YTaVr)_