### PR TITLE
Merge main into for-business (ciw toggleterm fix)

### DIFF
--- a/config/nvim/lua/terminal.lua
+++ b/config/nvim/lua/terminal.lua
@@ -6,7 +6,8 @@ vim.pack.add({ 'https://github.com/akinsho/toggleterm.nvim' })
 
 later(function()
   require('toggleterm').setup({
-    open_mapping = [[<C-\>]],
+    -- `open_mapping` を <C-\> に設定すると ciw など operator-pending の
+    -- キーシーケンスに割り込むため未設定。<leader>th/tv/tf や <leader>1..5 を使う。
     direction = 'horizontal',
     size = function(term)
       if term.direction == 'horizontal' then


### PR DESCRIPTION
## Summary
- `main` を `for-business` にマージ
- `ciw` などの operator-pending シーケンスと衝突する `toggleterm` の `open_mapping = [[<C-\>]]` 削除（#43）を `for-business` にも反映

## Test plan
- [ ] `nvim` を起動し、適当な単語上で `ciw` を実行 → ターミナルが起動せず word が削除されて insert モードに入る
- [ ] `<leader>th` / `<leader>tv` / `<leader>tf` でそれぞれの方向のターミナルが開く
- [ ] `<leader>1` 〜 `<leader>5` で番号付きターミナルが切り替わる

https://claude.ai/code/session_019mnk19otpr7uYCWB7YTaVr

---
_Generated by [Claude Code](https://claude.ai/code/session_019mnk19otpr7uYCWB7YTaVr)_