### PR TITLE
Randomize fastfetch logo: clawd / apple / nixos

### DIFF
--- a/home/fastfetch/config.jsonc
+++ b/home/fastfetch/config.jsonc
@@ -1,12 +1,8 @@
 {
   "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/master/doc/json_schema.json",
   "logo": {
-    "source": "~/.config/fastfetch/clawd.txt",
-    "type": "file",
-    "color": {
-      // Claude Code's clawd_body: rgb(215,119,87)
-      "1": "38;2;215;119;87"
-    },
+    "source": "nixos_small",
+    "type": "builtin",
     "padding": {
       "top": 1,
       "right": 3

--- a/home/fastfetch/config.jsonc
+++ b/home/fastfetch/config.jsonc
@@ -1,8 +1,12 @@
 {
   "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/master/doc/json_schema.json",
   "logo": {
-    "source": "nixos_small",
-    "type": "builtin",
+    "source": "~/.config/fastfetch/clawd.txt",
+    "type": "file",
+    "color": {
+      // Claude Code's clawd_body: rgb(215,119,87)
+      "1": "38;2;215;119;87"
+    },
     "padding": {
       "top": 1,
       "right": 3

--- a/home/zsh/.zshrc
+++ b/home/zsh/.zshrc
@@ -67,9 +67,10 @@ fi
 
 # fastfetch
 if command -v fastfetch &>/dev/null; then
-  case $((RANDOM % 2)) in
+  case $((RANDOM % 3)) in
     0) fastfetch ;;
     1) fastfetch --logo auto ;;
+    2) fastfetch --logo nixos_small ;;
   esac
 fi
 

--- a/home/zsh/.zshrc
+++ b/home/zsh/.zshrc
@@ -69,7 +69,7 @@ fi
 if command -v fastfetch &>/dev/null; then
   case $((RANDOM % 3)) in
     0) fastfetch ;;
-    1) fastfetch --logo auto ;;
+    1) fastfetch --logo apple ;;
     2) fastfetch --logo nixos_small ;;
   esac
 fi


### PR DESCRIPTION
## Summary
- `~/.zshrc` の fastfetch 起動を 3 択ランダム化:
  - `0`: `fastfetch`（config.jsonc 経由で **Claude clawd** ロゴ）
  - `1`: `fastfetch --logo apple`（**Apple** ロゴ）
  - `2`: `fastfetch --logo nixos_small`（**Nix** スノーフレーク）
- `home/fastfetch/config.jsonc` は元の clawd 設定のまま据え置き。

## Notes
- 元々は `clawd` と `--logo auto` の 2 択でした。`auto` は macOS で Apple ロゴ相当ですが、意図を明示するため `apple` 指定に変更しています。
- Nix のフルサイズが好みなら `nixos` に変更可能です。

## Test plan
- [ ] 新規シェルを複数回開いて 3 種のロゴが概ね均等に表示されること
- [ ] 各ロゴでレイアウト崩れがないこと
