### PR TITLE
Use 'default' as darwinConfiguration name for host-agnostic switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 MISE         := $(HOME)/.local/bin/mise
 NIX          := /nix/var/nix/profiles/default/bin/nix
-DARWIN_HOST  ?= $(shell scutil --get LocalHostName)
 DOTFILES_DIR := $(CURDIR)
 
 export PATH := $(HOME)/.local/bin:$(PATH)
@@ -27,9 +26,9 @@ nix-install: ## Install Nix via official installer (if not installed)
 
 darwin-switch: ## Apply nix-darwin + home-manager configuration (flake)
 	@if command -v darwin-rebuild >/dev/null 2>&1; then \
-		sudo darwin-rebuild switch --flake $(DOTFILES_DIR)#$(DARWIN_HOST); \
+		sudo darwin-rebuild switch --flake $(DOTFILES_DIR)#default; \
 	else \
-		sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake $(DOTFILES_DIR)#$(DARWIN_HOST); \
+		sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake $(DOTFILES_DIR)#default; \
 	fi
 	@echo ""
 	@echo "==> Run 'exec zsh -l' to reload the shell with the new configuration."

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
       ...
     }:
     {
-      darwinConfigurations."hayashiyuuseis-MacBook-Air" = nix-darwin.lib.darwinSystem {
+      darwinConfigurations."default" = nix-darwin.lib.darwinSystem {
         specialArgs = {
           inherit
             self
@@ -48,7 +48,7 @@
         modules = [
           ./darwin/configuration.nix
           home-manager.darwinModules.home-manager
-          { networking.hostName = "hayashiyuuseis-MacBook-Air"; }
+          { networking.hostName = "default"; }
           nix-homebrew.darwinModules.nix-homebrew
         ];
       };


### PR DESCRIPTION
## 概要

`for-business` ブランチで採用されている nix 記法のうち、汎用的に良いと判断した **darwinConfiguration 名の `"default"` 化**を main に適用します。

## 変更内容

- `flake.nix`: `darwinConfigurations."hayashiyuuseis-MacBook-Air"` → `darwinConfigurations."default"`、`networking.hostName` も `"default"` に統一
- `Makefile`: `DARWIN_HOST ?= $(shell scutil --get LocalHostName)` を削除し、`--flake .#default` をハードコード

## メリット

- マシン名に依存せず `darwin-rebuild switch --flake .#default` がどの機体でも通る（**PC移行に強い** — ホスト名をハードコードしないので移行時の編集不要）
- Makefile から `scutil` のシェルアウト依存が消えてシンプルになる

## 適用しなかったもの（for-business 固有のため）

- `username` は main の `"yuuki"` を維持（for-business の `"yukihayashi"` は業務用アカウント）
- claude プラグイン（3shake / slack / notion 等）、nvim の tinygo 削除、dependabot.yml 削除 などは環境固有のため見送り

https://claude.ai/code/session_01QtrQz3UR7PZKFLkjSkCgkq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtrQz3UR7PZKFLkjSkCgkq)_