### PR TITLE
chore: update nixpkgs input (2026-04-27 -> 2026-06-02)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777270315,
-        "narHash": "sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI=",
+        "lastModified": 1780365719,
+        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要

nix で管理しているツール群を更新するため、`flake.lock` の `nixpkgs` input を更新しました。

| input | before | after |
|-------|--------|-------|
| nixpkgs (nixpkgs-unstable) | `6368eda` (2026-04-27) | `ffa10e2` (2026-06-02) |

これにより `home.packages` の各種ツール（neovim / go / ripgrep / lazygit / starship / 各種 LSP など）が新しい版に更新されます。

## 方針

- **nixpkgs のみ更新**しています。`home-manager` / `nix-darwin` / `nix-homebrew` / `homebrew-*` の各 input は設定インフラの破壊リスクを避けるため**今回は据え置き**です。
- `home.stateVersion` は `25.11` のまま変更していません。
- `nix flake update nixpkgs` で再生成しているため narHash は正しく計算済みです。

## 検証

- この環境（Linux）に nix を導入し `nix flake update nixpkgs` を実行して lock を再生成しました。
- `nix flake metadata` で lock の整合性、JSON 妥当性を確認済み。
- ⚠️ flake は macOS (darwin) 専用設定のため、実ビルド（`darwin-rebuild switch`）の検証は Mac 側でのみ可能です。

## 適用手順（Mac 側）

```bash
cd ~/workspace/dotfiles
git pull origin claude/tool-update-check-X3JOE   # または main にマージ後 pull
make darwin-switch
```

## 補足（今回見送ったもの）

`home/mise/config.toml` の固定バージョンにも更新候補があります（別途検討）:
- `aqua:cli/cli` 2.87.3 → 2.93.0（v2 系マイナー更新、安全）
- `github:k1LoW/mo` v0.23.2 → v1.5.5（メジャーバージョン跨ぎのため要確認）

https://claude.ai/code/session_01K6SSd5xD7i3w8huq5TnNHB

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6SSd5xD7i3w8huq5TnNHB)_