### PR TITLE
ci: add flake build + nixfmt checks on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: nixfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Check formatting
+        run: nix run nixpkgs#nixfmt-rfc-style -- --check $(git ls-files '*.nix')
+
+  build:
+    name: build darwinConfiguration
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build darwin system
+        run: nix build --print-build-logs '.#darwinConfigurations.default.system'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -14,22 +13,22 @@ jobs:
     name: nixfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Check formatting
         run: nix run nixpkgs#nixfmt-rfc-style -- --check $(git ls-files '*.nix')
 
   build:
     name: build darwinConfiguration
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Build darwin system
         run: nix build --print-build-logs '.#darwinConfigurations.default.system'


### PR DESCRIPTION
## 概要

PR時に走るCIワークフロー (`.github/workflows/ci.yml`) を追加します。主目的は、dependabotなどによる依存更新で flake の評価・ビルドが壊れていないかを自動検知することです。

これまでこのリポジトリにはCIがなく、依存更新のマージ可否を手動で判断するしかありませんでした。

## 内容

トリガー: `main` 宛の pull request、および `workflow_dispatch`（手動実行）。

| ジョブ | ランナー | 内容 |
|--------|---------|------|
| `lint` | ubuntu-latest | 全 `.nix` ファイルが `nixfmt-rfc-style` の整形に従っているか `--check` で検証 |
| `build` | macos-latest | `aarch64-darwin` の `darwinConfigurations.default.system` を実際にビルドし、flakeの評価エラーやパッケージ更新による破壊を検出 |

- Nixのインストールは `DeterminateSystems/nix-installer-action`（リポジトリのMakefileがDeterminateインストーラを使っているため整合）。
- `concurrency` で同一refの古い実行はキャンセル。
- 構成が `aarch64-darwin` 専用のため、ビルド検証はmacOSランナーが必須。`macos-latest` はarm64で `hostPlatform` と一致。

## 補足 / 確認事項

- ビルドジョブはmacOSランナーを消費します（PR時のみ実行）。
- `lint` は既存 `.nix` ファイルが `nixfmt-rfc-style` 整形済みである前提です。未整形のファイルがあれば初回CIで該当箇所が指摘されます（その場合は `nix run nixpkgs#nixfmt-rfc-style -- .` で整形可能）。
- 外部キャッシュ（Magic Nix Cache はサービス終了済み）には依存していません。初回ビルドは時間がかかりますが、大半は `cache.nixos.org` の substitute で取得されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017zhEKbHFbFbZ8TQfEgkSdF)_