### PR TITLE
ci: add flake build + nixfmt checks on for-business PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [for-business]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: nixfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Check formatting
+        run: nix run nixpkgs#nixfmt-rfc-style -- --check $(git ls-files '*.nix')
+
+  build:
+    name: build darwinConfiguration
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Build darwin system
+        run: nix build --print-build-logs '.#darwinConfigurations.default.system'


### PR DESCRIPTION
## 概要

`for-business` ブランチ用のCIワークフロー (`.github/workflows/ci.yml`) を追加します。main向けCI（#62）と同等の内容を、for-business バリアントにも適用します。

GitHub Actions の仕様上、`pull_request` のワークフロー定義はベースブランチ側のものが使われるため、for-business 宛PRでCIを動かすにはワークフローが for-business ブランチ上に存在する必要があります。本PRをマージすることで有効になります。

## 内容

トリガー: `for-business` 宛の pull request のみ（`workflow_dispatch` なし）。

| ジョブ | ランナー | 内容 |
|--------|---------|------|
| `lint` | ubuntu-latest | 全 `.nix` ファイルが `nixfmt-rfc-style` の整形に従っているか `--check` |
| `build` | macos-26 | `darwinConfigurations.default.system` を実ビルドし、flake評価・依存更新による破壊を検出 |

- アクションはコミットSHAでピン留め（`actions/checkout` v7.0.0 / `DeterminateSystems/nix-installer-action` v22）。
- ランナーは最新GAの `macos-26`（arm64）でローカル環境に近づけています。
- `concurrency` で同一refの古い実行はキャンセル。
- for-business の `flake.nix` は username 差分のみで、ビルド対象は main と同じ `darwinConfigurations.default` です。

## 補足

- ビルドジョブはmacOSランナーを消費します（for-business 宛PR時のみ）。
- `lint` は既存 `.nix` が `nixfmt-rfc-style` 整形済みである前提です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017zhEKbHFbFbZ8TQfEgkSdF)_