### PR TITLE
chore(deps): bump nixpkgs to align with home-manager (26.11)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778124196,
-        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- `nixpkgs` lock のみを 26.05 系 (`68a8af93`, 2026-05-07) → 26.11 系 (`89570f24`, 2026-06-23) に更新
- これにより home-manager (`4c5c1e8b`, 2026-06-08, 26.11 系) と release 系列が揃い、`darwin-rebuild` 時の `Home Manager version 26.11 and Nixpkgs version 26.05` 警告を解消
- `flake.nix` は変更なし (`nixpkgs-unstable` 指定のまま)。`follows = "nixpkgs"` は依存ライブラリ供給を揃える設定で release 系列の自動同期はしないため、lock の手動更新が必要だった

## Test plan

- [x] `nix flake metadata --json` で nixpkgs/home-manager の `lastModified` が同時期 (2026-06) に揃ったことを確認
- [x] `darwin-rebuild build --flake .#default` が成功し、`Home Manager version` 警告が出力されないことを確認
- [ ] マージ後、ローカルで `darwin-rebuild switch` 実行し実 system 反映時にも警告が出ないことを確認

## Note

別件 deprecation 警告 `nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.` が新たに出ているが、本 PR のスコープ外 (別 PR で `pkgs.nixfmt-rfc-style` → `pkgs.nixfmt` 置換予定)。