### PR TITLE
refactor(nvim): migrate mini.deps to vim.pack and MiniMisc.safely

### DIFF
--- a/home/nvim/.luarc.json
+++ b/home/nvim/.luarc.json
@@ -3,7 +3,6 @@
   "runtime.version": "LuaJIT",
   "diagnostics.globals": [
     "vim",
-    "MiniDeps",
     "MiniIcons",
     "MiniTrailspace",
     "MiniGit",

--- a/home/nvim/init.lua
+++ b/home/nvim/init.lua
@@ -1,21 +1,13 @@
 vim.loader.enable()
 
--- Clone 'mini.nvim' manually in a way that it gets managed by 'mini.deps'
-local path_package = vim.fn.stdpath('data') .. '/site/'
-local mini_path = path_package .. 'pack/deps/start/mini.nvim'
-if vim.uv.fs_stat(mini_path) == nil then
-  vim.cmd('echo "Installing `mini.nvim`" | redraw')
-  local clone_cmd = {
-    'git', 'clone', '--filter=blob:none',
-    'https://github.com/echasnovski/mini.nvim', mini_path
-  }
-  vim.fn.system(clone_cmd)
-  vim.cmd('packadd mini.nvim | helptags ALL')
-  vim.cmd('echo "Installed `mini.nvim`" | redraw')
-end
+-- mini.deps は最新の mini.nvim で開発が凍結されたため、プラグイン管理は
+-- Neovim 組み込みの vim.pack に移行。mini.nvim 本体も vim.pack で入れる。
+vim.pack.add({ 'https://github.com/echasnovski/mini.nvim' })
 
--- Set up 'mini.deps' (customize to your liking)
-require('mini.deps').setup({ path = { package = path_package } })
+-- 各モジュールは MiniDeps.now/later の代わりに MiniMisc.safely を使う。
+-- MiniMisc グローバルは require('mini.misc').setup() で生成されるため、
+-- 他モジュールを読み込む前にここでセットアップしておく。
+require('mini.misc').setup()
 
 -- keymaps
 -- jkで抜ける系

--- a/home/nvim/lua/appearance.lua
+++ b/home/nvim/lua/appearance.lua
@@ -2,10 +2,10 @@
 
 vim.o.winbar = " %m %f "
 
-local now, later = MiniDeps.now, MiniDeps.later
+local safely = MiniMisc.safely
 
 -- colorscheme
-now(function()
+safely('now', function()
   vim.pack.add({ 'https://github.com/folke/tokyonight.nvim' })
   require("tokyonight").setup({
     style = "storm",
@@ -25,33 +25,33 @@ now(function()
   vim.cmd.colorscheme('tokyonight')
 end)
 
-later(function()
+safely('later', function()
   vim.pack.add({ 'https://github.com/vim-jp/vimdoc-ja' })
   vim.opt.helplang:prepend('ja')
 end)
 
 -- Simple plugins
-now(function()
+safely('now', function()
   require('mini.icons').setup()
   MiniIcons.mock_nvim_web_devicons()
 end)
-later(require('mini.indentscope').setup)
+safely('later', require('mini.indentscope').setup)
 
 -- statusline
-now(function()
+safely('now', function()
   require('mini.statusline').setup()
   vim.opt.laststatus = 3
   vim.opt.cmdheight = 0
 end)
 
 -- notify
-now(function()
+safely('now', function()
   require('mini.notify').setup()
   vim.notify = require('mini.notify').make_notify({})
 end)
 
 -- hipatterns
-later(function()
+safely('later', function()
   local hipatterns = require('mini.hipatterns')
   local hi_words = require('mini.extra').gen_highlighter.words
   hipatterns.setup({
@@ -65,7 +65,7 @@ later(function()
 end)
 
 -- trailspace
-later(function()
+safely('later', function()
   require('mini.trailspace').setup()
   vim.api.nvim_create_user_command(
     'Trim',
@@ -78,7 +78,7 @@ later(function()
 end)
 
 -- clue (全体のキーバインドヒント)
-later(function()
+safely('later', function()
   local function mode_nx(keys)
     return { mode = 'n', keys = keys }, { mode = 'x', keys = keys }
   end

--- a/home/nvim/lua/edit.lua
+++ b/home/nvim/lua/edit.lua
@@ -70,18 +70,20 @@ vim.api.nvim_create_user_command('CopyPath', function()
   print("Copied: " .. path)
 end, {})
 
-local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
+local safely = MiniMisc.safely
 
 -- treesitter
-now(function()
-  add({
-    source = 'https://github.com/nvim-treesitter/nvim-treesitter',
-    hooks = {
-      post_checkout = function()
+safely('now', function()
+  -- mini.deps の hooks.post_checkout 相当: install/update 時に parser を更新
+  vim.api.nvim_create_autocmd('PackChanged', {
+    callback = function(ev)
+      if ev.data.spec.name == 'nvim-treesitter'
+          and (ev.data.kind == 'install' or ev.data.kind == 'update') then
         vim.cmd.TSUpdate()
       end
-    },
+    end,
   })
+  vim.pack.add({ 'https://github.com/nvim-treesitter/nvim-treesitter' })
   require('nvim-treesitter').install({
     'lua', 'vim', 'markdown', 'markdown_inline', 'bash', 'yaml', 'zsh',
     'tsx', 'typescript', 'html',
@@ -112,11 +114,9 @@ now(function()
   })
 end)
 
-later(function()
-  add({
-    source = 'https://github.com/folke/ts-comments.nvim',
-    depends = { 'nvim-treesitter/nvim-treesitter' },
-  })
+safely('later', function()
+  -- nvim-treesitter は treesitter ブロックで既に追加済み (depends 相当)
+  vim.pack.add({ 'https://github.com/folke/ts-comments.nvim' })
   require('ts-comments').setup()
 end)
 
@@ -126,8 +126,8 @@ vim.opt.foldlevel = 99
 
 -- Simple plugins
 for _, name in ipairs({ 'pairs', 'surround', 'move', 'bracketed', 'jump2d' }) do
-  later(require('mini.' .. name).setup)
+  safely('later', require('mini.' .. name).setup)
 end
 
 -- basics
-now(require('mini.basics').setup)
+safely('now', require('mini.basics').setup)

--- a/home/nvim/lua/git.lua
+++ b/home/nvim/lua/git.lua
@@ -1,10 +1,10 @@
 -- Git系
 
-local later = MiniDeps.later
+local safely = MiniMisc.safely
 
-later(require('mini.diff').setup)
+safely('later', require('mini.diff').setup)
 
-later(function()
+safely('later', function()
   require('mini.git').setup()
 
   vim.keymap.set({ 'n', 'x' }, '<space>gs', MiniGit.show_at_cursor, { desc = 'Show at cursor' })

--- a/home/nvim/lua/lsp/init.lua
+++ b/home/nvim/lua/lsp/init.lua
@@ -1,8 +1,8 @@
 -- config of lsp
 
-local now = MiniDeps.now
+local safely = MiniMisc.safely
 
-now(function()
+safely('now', function()
   vim.pack.add({ 'https://github.com/pcolladosoto/tinygo.nvim' })
   local tinygo = require("tinygo")
   tinygo.setup({})

--- a/home/nvim/lua/nav.lua
+++ b/home/nvim/lua/nav.lua
@@ -1,14 +1,12 @@
 -- 探索系
 
-local now, later = MiniDeps.now, MiniDeps.later
+local safely = MiniMisc.safely
 
 -- starter
-now(require('mini.starter').setup)
+safely('now', require('mini.starter').setup)
 
--- misc
-now(function()
-  require('mini.misc').setup()
-
+-- misc (mini.misc.setup() は init.lua で実行済み)
+safely('now', function()
   MiniMisc.setup_restore_cursor()
   vim.api.nvim_create_user_command('Zoom', function()
     MiniMisc.zoom(0, {})
@@ -17,7 +15,7 @@ now(function()
 end)
 
 -- files
-now(function()
+safely('now', function()
   require('mini.files').setup()
 
   -- mini.files.setup() がハイライトを上書きするため、setup() 後に再設定
@@ -43,7 +41,7 @@ now(function()
 end)
 
 -- pick
-later(function()
+safely('later', function()
   local prev_paste = vim.paste
   require('mini.pick').setup()
 

--- a/home/nvim/lua/terminal.lua
+++ b/home/nvim/lua/terminal.lua
@@ -1,10 +1,10 @@
 -- Terminal系
 
-local later = MiniDeps.later
+local safely = MiniMisc.safely
 
 vim.pack.add({ 'https://github.com/akinsho/toggleterm.nvim' })
 
-later(function()
+safely('later', function()
   require('toggleterm').setup({
     -- `open_mapping` を <C-\> に設定すると ciw など operator-pending の
     -- キーシーケンスに割り込むため未設定。<leader>th/tv/tf や <leader>1..5 を使う。


### PR DESCRIPTION
## 背景

最新の `mini.nvim` で `mini.deps` の開発が**凍結 (frozen)** されました。公式ドキュメントは Neovim 0.12+ では以下を推奨しています:

- プラグイン管理: 組み込みの `vim.pack`
- `MiniDeps.now()` / `MiniDeps.later()` の代替: `MiniMisc.safely('now'/'later', fn)`

これを受けて Neovim 設定を移行します。

## 変更内容

- **`init.lua`**: ブートストラップを書き換え。`mini.nvim` 本体を `vim.pack.add` で導入し、`require('mini.misc').setup()` を**他モジュールの読み込み前に**実行。`MiniMisc` グローバルは `setup()` で初めて生成されるため、各モジュールで `MiniMisc.safely` を使えるよう先に用意する。
- **`MiniDeps.add(...)` → `vim.pack.add(...)`**
  - treesitter の `hooks.post_checkout`(`TSUpdate`)は `PackChanged` autocmd で再現。
  - `ts-comments` の `depends = { nvim-treesitter }` は、treesitter が同じファイルで先に追加済みのため不要。
- **`now()` / `later()` → `MiniMisc.safely('now'/'later', ...)`** を全ファイルで適用 (`appearance.lua`, `edit.lua`, `nav.lua`, `git.lua`, `terminal.lua`, `lsp/init.lua`)。
- **`nav.lua`**: `init.lua` でセットアップ済みになった `mini.misc.setup()` の重複呼び出しを削除。
- **`.luarc.json`**: 不要になった `MiniDeps` グローバルを削除。

## 確認事項 / 注意

- 本環境に Lua/Neovim インタプリタが無いため構文の機械チェックは未実施。手元の Neovim 0.12+ で起動確認をお願いします(特に初回起動時のプラグイン clone と treesitter parser のインストール)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhQR9TdszBTQ2XEZMbbCoz)_