### PR TITLE
ci: only run nix build/fmt when nix files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "**/*.nix"
+      - "flake.lock"
+      - ".github/workflows/ci.yml"
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## What

Add a `paths` filter to the CI workflow so it only triggers when nix-relevant files change:

```yaml
on:
  pull_request:
    branches: [main]
    paths:
      - "**/*.nix"
      - "flake.lock"
      - ".github/workflows/ci.yml"
```

## Why

Currently CI runs on **every** PR. Both jobs — the `nixfmt` check and the expensive `macos-26` darwin build — run even when no nix config was touched (e.g. PRs that only change nvim lua, wezterm, README). That's wasted CI time and macOS runner minutes.

With this filter, PRs that don't touch `.nix` files or `flake.lock` skip the workflow entirely. The workflow file itself is included so changes to CI re-validate.

## Note

If `nixfmt` / `build darwinConfiguration` are configured as **required status checks** in branch protection, skipped runs report no status and can block merging. If so, either drop them from required checks or convert to a "skip" sentinel job. Let me know and I can adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhHQrJp4TeYPZ2buJGSKHg)_