### PR TITLE
chore: mainの内容をfor-businessに取り込む

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - "**/*.nix"
+      - "flake.lock"
+      - ".github/workflows/ci.yml"
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/home/claude/settings.json
+++ b/home/claude/settings.json
@@ -91,6 +91,7 @@
     ],
     "defaultMode": "plan"
   },
+  "model": "claude-opus-4-7[1m]",
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.js"
@@ -173,7 +174,11 @@
   "effortLevel": "xhigh",
   "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "latest",
+  "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,
-  "voiceEnabled": false,
-  "skipAutoPermissionPrompt": true
+  "skipWorkflowUsageWarning": true,
+  "inputNeededNotifEnabled": false,
+  "agentPushNotifEnabled": true,
+  "skipAutoPermissionPrompt": true,
+  "voiceEnabled": false
 }

--- a/home/nvim/.luarc.json
+++ b/home/nvim/.luarc.json
@@ -3,7 +3,6 @@
   "runtime.version": "LuaJIT",
   "diagnostics.globals": [
     "vim",
-    "MiniDeps",
     "MiniIcons",
     "MiniTrailspace",
     "MiniGit",

--- a/home/nvim/init.lua
+++ b/home/nvim/init.lua
@@ -1,21 +1,13 @@
 vim.loader.enable()
 
--- Clone 'mini.nvim' manually in a way that it gets managed by 'mini.deps'
-local path_package = vim.fn.stdpath('data') .. '/site/'
-local mini_path = path_package .. 'pack/deps/start/mini.nvim'
-if vim.uv.fs_stat(mini_path) == nil then
-  vim.cmd('echo "Installing `mini.nvim`" | redraw')
-  local clone_cmd = {
-    'git', 'clone', '--filter=blob:none',
-    'https://github.com/echasnovski/mini.nvim', mini_path
-  }
-  vim.fn.system(clone_cmd)
-  vim.cmd('packadd mini.nvim | helptags ALL')
-  vim.cmd('echo "Installed `mini.nvim`" | redraw')
-end
+-- mini.deps は最新の mini.nvim で開発が凍結されたため、プラグイン管理は
+-- Neovim 組み込みの vim.pack に移行。mini.nvim 本体も vim.pack で入れる。
+vim.pack.add({ 'https://github.com/echasnovski/mini.nvim' })
 
--- Set up 'mini.deps' (customize to your liking)
-require('mini.deps').setup({ path = { package = path_package } })
+-- 各モジュールは MiniDeps.now/later の代わりに MiniMisc.safely を使う。
+-- MiniMisc グローバルは require('mini.misc').setup() で生成されるため、
+-- 他モジュールを読み込む前にここでセットアップしておく。
+require('mini.misc').setup()
 
 -- keymaps
 -- jkで抜ける系

--- a/home/nvim/lua/appearance.lua
+++ b/home/nvim/lua/appearance.lua
@@ -2,10 +2,10 @@
 
 vim.o.winbar = " %m %f "
 
-local now, later = MiniDeps.now, MiniDeps.later
+local safely = MiniMisc.safely
 
 -- colorscheme
-now(function()
+safely('now', function()
   vim.pack.add({ 'https://github.com/folke/tokyonight.nvim' })
   require("tokyonight").setup({
     style = "storm",
@@ -25,33 +25,33 @@ now(function()
   vim.cmd.colorscheme('tokyonight')
 end)
 
-later(function()
+safely('later', function()
   vim.pack.add({ 'https://github.com/vim-jp/vimdoc-ja' })
   vim.opt.helplang:prepend('ja')
 end)
 
 -- Simple plugins
-now(function()
+safely('now', function()
   require('mini.icons').setup()
   MiniIcons.mock_nvim_web_devicons()
 end)
-later(require('mini.indentscope').setup)
+safely('later', require('mini.indentscope').setup)
 
 -- statusline
-now(function()
+safely('now', function()
   require('mini.statusline').setup()
   vim.opt.laststatus = 3
   vim.opt.cmdheight = 0
 end)
 
 -- notify
-now(function()
+safely('now', function()
   require('mini.notify').setup()
   vim.notify = require('mini.notify').make_notify({})
 end)
 
 -- hipatterns
-later(function()
+safely('later', function()
   local hipatterns = require('mini.hipatterns')
   local hi_words = require('mini.extra').gen_highlighter.words
   hipatterns.setup({
@@ -65,7 +65,7 @@ later(function()
 end)
 
 -- trailspace
-later(function()
+safely('later', function()
   require('mini.trailspace').setup()
   vim.api.nvim_create_user_command(
     'Trim',
@@ -78,7 +78,7 @@ later(function()
 end)
 
 -- clue (全体のキーバインドヒント)
-later(function()
+safely('later', function()
   local function mode_nx(keys)
     return { mode = 'n', keys = keys }, { mode = 'x', keys = keys }
   end

--- a/home/nvim/lua/edit.lua
+++ b/home/nvim/lua/edit.lua
@@ -70,18 +70,20 @@ vim.api.nvim_create_user_command('CopyPath', function()
   print("Copied: " .. path)
 end, {})
 
-local add, now, later = MiniDeps.add, MiniDeps.now, MiniDeps.later
+local safely = MiniMisc.safely
 
 -- treesitter
-now(function()
-  add({
-    source = 'https://github.com/nvim-treesitter/nvim-treesitter',
-    hooks = {
-      post_checkout = function()
+safely('now', function()
+  -- mini.deps の hooks.post_checkout 相当: install/update 時に parser を更新
+  vim.api.nvim_create_autocmd('PackChanged', {
+    callback = function(ev)
+      if ev.data.spec.name == 'nvim-treesitter'
+          and (ev.data.kind == 'install' or ev.data.kind == 'update') then
         vim.cmd.TSUpdate()
       end
-    },
+    end,
   })
+  vim.pack.add({ 'https://github.com/nvim-treesitter/nvim-treesitter' })
   require('nvim-treesitter').install({
     'lua', 'vim', 'markdown', 'markdown_inline', 'bash', 'yaml', 'zsh',
     'tsx', 'typescript', 'html',
@@ -112,11 +114,9 @@ now(function()
   })
 end)
 
-later(function()
-  add({
-    source = 'https://github.com/folke/ts-comments.nvim',
-    depends = { 'nvim-treesitter/nvim-treesitter' },
-  })
+safely('later', function()
+  -- nvim-treesitter は treesitter ブロックで既に追加済み (depends 相当)
+  vim.pack.add({ 'https://github.com/folke/ts-comments.nvim' })
   require('ts-comments').setup()
 end)
 
@@ -126,8 +126,8 @@ vim.opt.foldlevel = 99
 
 -- Simple plugins
 for _, name in ipairs({ 'pairs', 'surround', 'move', 'bracketed', 'jump2d' }) do
-  later(require('mini.' .. name).setup)
+  safely('later', require('mini.' .. name).setup)
 end
 
 -- basics
-now(require('mini.basics').setup)
+safely('now', require('mini.basics').setup)

--- a/home/nvim/lua/git.lua
+++ b/home/nvim/lua/git.lua
@@ -1,10 +1,10 @@
 -- Git系
 
-local later = MiniDeps.later
+local safely = MiniMisc.safely
 
-later(require('mini.diff').setup)
+safely('later', require('mini.diff').setup)
 
-later(function()
+safely('later', function()
   require('mini.git').setup()
 
   vim.keymap.set({ 'n', 'x' }, '<space>gs', MiniGit.show_at_cursor, { desc = 'Show at cursor' })

--- a/home/nvim/lua/lsp/init.lua
+++ b/home/nvim/lua/lsp/init.lua
@@ -1,8 +1,8 @@
 -- config of lsp
 
-local now = MiniDeps.now
+local safely = MiniMisc.safely
 
-now(function()
+safely('now', function()
   vim.pack.add({ 'https://github.com/pcolladosoto/tinygo.nvim' })
   local tinygo = require("tinygo")
   tinygo.setup({})

--- a/home/nvim/lua/nav.lua
+++ b/home/nvim/lua/nav.lua
@@ -1,14 +1,12 @@
 -- 探索系
 
-local now, later = MiniDeps.now, MiniDeps.later
+local safely = MiniMisc.safely
 
 -- starter
-now(require('mini.starter').setup)
+safely('now', require('mini.starter').setup)
 
--- misc
-now(function()
-  require('mini.misc').setup()
-
+-- misc (mini.misc.setup() は init.lua で実行済み)
+safely('now', function()
   MiniMisc.setup_restore_cursor()
   vim.api.nvim_create_user_command('Zoom', function()
     MiniMisc.zoom(0, {})
@@ -17,7 +15,7 @@ now(function()
 end)
 
 -- files
-now(function()
+safely('now', function()
   require('mini.files').setup()
 
   -- mini.files.setup() がハイライトを上書きするため、setup() 後に再設定
@@ -43,7 +41,7 @@ now(function()
 end)
 
 -- pick
-later(function()
+safely('later', function()
   local prev_paste = vim.paste
   require('mini.pick').setup()
 

--- a/home/nvim/lua/terminal.lua
+++ b/home/nvim/lua/terminal.lua
@@ -1,10 +1,10 @@
 -- Terminal系
 
-local later = MiniDeps.later
+local safely = MiniMisc.safely
 
 vim.pack.add({ 'https://github.com/akinsho/toggleterm.nvim' })
 
-later(function()
+safely('later', function()
   require('toggleterm').setup({
     -- `open_mapping` を <C-\> に設定すると ciw など operator-pending の
     -- キーシーケンスに割り込むため未設定。<leader>th/tv/tf や <leader>1..5 を使う。

--- a/home/wezterm/wezterm.lua
+++ b/home/wezterm/wezterm.lua
@@ -17,11 +17,40 @@ config.send_composed_key_when_right_alt_is_pressed = false
 config.window_background_opacity = 0.85
 config.macos_window_background_blur = 20
 
--- weztermのデフォルト背景は真っ黒(#000000)でghosttyより暗く沈むため、
--- ghosttyのデフォルト背景色(#292c33)に合わせる
+-- weztermのデフォルトはANSI greenが鮮やか(緑寄りの印象)になるため、
+-- ghosttyの内蔵デフォルトpalette (Tomorrow系/One Darkの混合, 既存builtinに一致なし) を直接移植
+-- 値は `ghostty +show-config --default` から取得
 config.colors = {
-	background = "#292c33",
+	foreground = "#ffffff",
+	background = "#282c34",
+	cursor_bg = "#ffffff",
+	cursor_fg = "#000000",
+	cursor_border = "#ffffff",
+	ansi = {
+		"#1d1f21",
+		"#cc6666",
+		"#b5bd68",
+		"#f0c674",
+		"#81a2be",
+		"#b294bb",
+		"#8abeb7",
+		"#c5c8c6",
+	},
+	brights = {
+		"#666666",
+		"#d54e53",
+		"#b9ca4a",
+		"#e7c547",
+		"#7aa6da",
+		"#c397d8",
+		"#70c0b1",
+		"#eaeaea",
+	},
 }
+
+-- claude codeなどが出力する素のURL文字列をSUPER+クリックで開けるようにする
+-- (weztermはデフォルトでhyperlink_rulesが空 = URLを認識しない)
+config.hyperlink_rules = wezterm.default_hyperlink_rules()
 
 -- WebGpuだとDock(launchd)起動時にGPUコンテキスト初期化に失敗して
 -- 透過が効かないことがあるため、描画をOpenGLに固定する
@@ -41,6 +70,26 @@ config.inactive_pane_hsb = {
 -- ・タブが1つのときはタブバーごと隠す (ghosttyと同じ挙動)
 config.use_fancy_tab_bar = true
 config.hide_tab_bar_if_only_one_tab = true
+
+-- タブバー/タイトルバーの色を ghostty palette に揃える
+-- (デフォルトのteal/purple系を消し、palette black / bg / 8 / 7 / foreground の無彩色寄りで構成)
+local tab_idle = { bg_color = "#1d1f21", fg_color = "#666666" }
+local tab_hover = { bg_color = "#282c34", fg_color = "#c5c8c6" }
+config.window_frame = {
+	active_titlebar_bg = "#1d1f21",
+	inactive_titlebar_bg = "#1d1f21",
+}
+config.colors.tab_bar = {
+	background = "#1d1f21",
+	active_tab = {
+		bg_color = "#282c34",
+		fg_color = "#ffffff",
+	},
+	inactive_tab = tab_idle,
+	inactive_tab_hover = tab_hover,
+	new_tab = tab_idle,
+	new_tab_hover = tab_hover,
+}
 
 -- "1:" のインデックスを消して、タブ名(無ければプログラム名)だけ表示する
 wezterm.on("format-tab-title", function(tab)


### PR DESCRIPTION
## 概要

`main` の変更を `for-business` ブランチに取り込むマージです。

## コンフリクトの解決内容

4ファイルでコンフリクトが発生し、以下の方針で解決しました。

- **`.github/workflows/ci.yml`**: トリガー対象ブランチを `for-business` のまま維持しつつ、`main` で追加された path フィルタ（`**/*.nix` / `flake.lock` / `ci.yml` 変更時のみ実行）を取り込み。
- **`home/claude/settings.json`**: `main` で追加された `skipWorkflowUsageWarning` / `inputNeededNotifEnabled` / `agentPushNotifEnabled` を取り込み。
- **`home/nvim/lua/lsp/init.lua`**: `main` の `MiniDeps` → `vim.pack` / `MiniMisc.safely` 移行を採用。
- **`home/wezterm/wezterm.lua`**: for-business は従来から wezterm を意図的に除外しているため（前回マージ #65 と同様）、削除を維持。

## 確認

- コンフリクトマーカーの残存なし
- wezterm への参照漏れなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUnE1coN2h995trx6AgstP)_