### PR TITLE
feat(gopls): gopls-lazy を nvim / mise / Claude Code の Go LSP に統一

### DIFF
--- a/home/claude/settings.json
+++ b/home/claude/settings.json
@@ -121,7 +121,8 @@
     "command": "~/.claude/statusline.js"
   },
   "enabledPlugins": {
-    "gopls-lsp@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": false,
+    "gopls-lazy-lsp@skills-dir": true,
     "lua-lsp@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
     "example-skills@anthropic-agent-skills": true,

--- a/home/claude/skills/gopls-lazy-lsp/.claude-plugin/plugin.json
+++ b/home/claude/skills/gopls-lazy-lsp/.claude-plugin/plugin.json
@@ -1,6 +1,9 @@
 {
   "name": "gopls-lazy-lsp",
   "version": "0.1.0",
+  "author": {
+    "name": "rin2yh"
+  },
   "description": "sivchari/gopls-lazy を Claude Code の Go LSP として使う。gopls への drop-in プロキシで、大規模 Go モノレポの型チェックを動的にスコープし CPU/メモリを削減する。skills-dir プラグインとして in-place ロードされる（marketplace 不要）。",
   "lspServers": {
     "go": {

--- a/home/claude/skills/gopls-lazy-lsp/.claude-plugin/plugin.json
+++ b/home/claude/skills/gopls-lazy-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "gopls-lazy-lsp",
+  "version": "0.1.0",
+  "description": "sivchari/gopls-lazy を Claude Code の Go LSP として使う。gopls への drop-in プロキシで、大規模 Go モノレポの型チェックを動的にスコープし CPU/メモリを削減する。skills-dir プラグインとして in-place ロードされる（marketplace 不要）。",
+  "lspServers": {
+    "go": {
+      "command": "gopls-lazy",
+      "extensionToLanguage": {
+        ".go": "go"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 概要

`sivchari/gopls-lazy`（gopls への drop-in プロキシ。大規模 Go モノレポの型チェックを動的にスコープし CPU/メモリ footprint を削減）を、**Neovim・mise に続き Claude Code の Go LSP にも**適用して統一する。

## 変更内容

### mise / Neovim（既存コミット `fcb1385`）
- `home/mise/config.toml`: `github:sivchari/gopls-lazy@v0.3.0` を追加
- `home/nvim/lua/lsp/gopls.lua`: 起動コマンドを `gopls` → `gopls-lazy` に変更

### Claude Code（本コミット `9987870`）
- Claude Code v2.0.74+ の LSP プラグイン機構を利用
- `home/claude/skills/gopls-lazy-lsp/.claude-plugin/plugin.json` を新規追加し、`lspServers.go.command = "gopls-lazy"` を宣言
- `home/claude/settings.json`: 公式 `gopls-lsp@claude-plugins-official`（`gopls serve`）を無効化し、`gopls-lazy-lsp@skills-dir` を有効化

## 設計上のポイント

- **skills-dir プラグイン**（`~/.claude/skills/<name>/.claude-plugin/plugin.json`）として in-place ロードされるため、marketplace 登録も install ステップも不要。
- `~/.claude/skills` は既に `mkOutOfStoreSymlink` でディレクトリごと symlink 済みなので、配下へのサブディレクトリ追加は **nix rebuild 不要**で反映される（`home.file` へのエントリ追加が発生しない）。
- 実 `gopls` は `make tools`（`go install golang.org/x/tools/gopls@latest`）で導入済みで、`gopls-lazy` が PATH 上の `gopls` にプロキシする。バイナリ追加は不要。

## 動作確認

- [ ] Claude Code 再起動（または `/reload-plugins`）後、`/plugin` の Errors タブに `gopls-lazy` 関連エラーが出ないこと
- [ ] Go ファイル編集後に診断が Claude のコンテキストへ反映されること（go-to-definition / hover 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Rf6W5zEyCWSuL8eoBGGHF

---
_Generated by [Claude Code](https://claude.ai/code/session_017Rf6W5zEyCWSuL8eoBGGHF)_