### PR TITLE
feat(zsh): add tinygo-autocmpl completion

### DIFF
--- a/home/mise/config.toml
+++ b/home/mise/config.toml
@@ -2,6 +2,7 @@
 "aqua:anthropics/claude-code" = "latest"
 "aqua:cli/cli" = "2.87.3"
 "github:k1LoW/mo" = "v0.23.2"
+"github:sago35/tinygo-autocmpl" = "v0.8.0"
 "github:sivchari/gopls-lazy" = "v0.3.0"
 node = "latest"
 "npm:ccusage" = "latest"

--- a/home/zsh/.zshrc
+++ b/home/zsh/.zshrc
@@ -48,6 +48,11 @@ if command -v mise &>/dev/null; then
   eval "$(mise activate zsh --shims)"
 fi
 
+# tinygo completion (via tinygo-autocmpl; needs mise shims on PATH)
+if command -v tinygo-autocmpl &>/dev/null; then
+  eval "$(tinygo-autocmpl --completion-script-zsh)"
+fi
+
 # starship
 if command -v starship &>/dev/null; then
   eval "$(starship init zsh)"


### PR DESCRIPTION
## 概要

[sago35/tinygo-autocmpl](https://github.com/sago35/tinygo-autocmpl) を導入し、`tinygo` コマンドの zsh 補完を有効化する。

## 変更内容

- **`home/mise/config.toml`**: `github:sago35/tinygo-autocmpl` を `v0.8.0` にピン留めして追加。既存の `github:` バックエンド（`k1LoW/mo` / `sivchari/gopls-lazy`）と同じパターン。goreleaser 標準のアセット名（`tinygo-autocmpl_0.8.0_darwin_arm64.tar.gz` など）なので mise が自動でプラットフォームを解決する。
- **`home/zsh/.zshrc`**: `eval "$(tinygo-autocmpl --completion-script-zsh)"` を追加。`starship` / `zoxide` と同様にバイナリの存在をガードし、`mise activate --shims` の**後**に配置して shim が PATH に載った状態で実行されるようにした。

## 適用手順

`config.toml` / `.zshrc` は symlink 実体なので `darwin-rebuild` は不要。バイナリのインストールのみ必要:

```bash
mise install   # または make tools
```

新しいシェルを開くと `tinygo <Tab>` で補完が効く。

## 補足

補完対象の `tinygo` 本体はまだ `home.packages` / mise に含まれていない。補完は `tinygo` が PATH 上にある場合に機能する。tinygo 本体も入れたい場合は別途追加可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJnZEDdKPihp36mKz543a)_