### PR TITLE
chore(deps): bump nixpkgs and nix-darwin together

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761792,
-        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "lastModified": 1783395956,
+        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782175435,
-        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
+        "lastModified": 1783475452,
+        "narHash": "sha256-3S92fSuv32mjJz2Qb2F4405c21J55F4NIphz5K6hxco=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
+        "rev": "05988b07fb05cbcb50be6bce197b4b5f75b5e61b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Combines two Dependabot PRs that must be bumped in lockstep:

- **#81** nixpkgs `89570f2` → `05988b0`
- **#83** nix-darwin `a1fa429` → `d5bd9cd`

## Why combined

Bumping either input **alone** fails the `build darwinConfiguration` CI job on the `darwin-manual-html` derivation:

- **#81 alone** (new nixpkgs + old nix-darwin): `nixos-render-docs manual html: error: --toc-depth has been removed, use --sidebar-depth instead` — the newer nixpkgs dropped `--toc-depth`, but the old nix-darwin still passes it.
- **#83 alone** (new nix-darwin + old nixpkgs): `nixos-render-docs: error: unrecognized arguments: --sidebar-depth` — the newer nix-darwin adopts `--sidebar-depth`, which the old nixpkgs `nixos-render-docs` doesn't yet support.

Since `nix-darwin` uses `inputs.nixpkgs.follows = "nixpkgs"`, its manual is rendered with the top-level nixpkgs `nixos-render-docs`, so the two revisions have to move together. Bumping both matches the `nixos-render-docs` API and unblocks the build.

## Changes

`flake.lock` only — the `nixpkgs` and `nix-darwin` locked nodes (rev / narHash / lastModified). No `.nix` files touched; `nixfmt` is unaffected.

## Notes

Merging this makes Dependabot's #81 and #83 redundant; they can be closed once this lands. The other three Dependabot bumps (homebrew-cask #80, home-manager #82, homebrew-core #84) passed CI independently and were merged separately.


---
_Generated by [Claude Code](https://claude.ai/code/session_016WThNHb4txVH79gMdnposV)_