### PR TITLE
feat(nvim): mini.tabline を有効化してバッファ一覧を表示する

### DIFF
--- a/home/nvim/lua/appearance.lua
+++ b/home/nvim/lua/appearance.lua
@@ -44,6 +44,12 @@ safely('now', function()
   vim.opt.cmdheight = 0
 end)
 
+-- tabline (開いているバッファ一覧を上部に表示)
+-- アイコンを出すため mini.icons のセットアップ後に読み込む
+safely('now', function()
+  require('mini.tabline').setup()
+end)
+
 -- notify
 safely('now', function()
   require('mini.notify').setup()


### PR DESCRIPTION
## 変更内容

`home/nvim/lua/appearance.lua` で `mini.tabline` をセットアップし、開いているバッファ一覧を画面上部のタブラインに表示するようにしました。

- これまで `mini.nvim` は導入済みでしたが `mini.tabline` だけセットアップされておらず、バッファ一覧は `<space>b`（`MiniPick.builtin.buffers`）でピッカーを開かないと確認できませんでした。
- アイコン表示のため、`mini.icons` のセットアップ後（`statusline` の直後）に `now` で読み込んでいます。
- `mini.tabline.setup()` が `showtabline = 2` を設定するため、常時表示になります。`laststatus = 3` / `winbar` の設定はそのままです。

## 動作確認

Neovim nightly (v0.13.0-dev) を隔離した XDG 環境に用意し、この設定をそのまま起動して確認しました。

変更後（3 バッファを開いた状態）:

```
showtabline = 2
tabline     = %!v:lua.MiniTabline.make_tabline_string()
rendered    = [ init.lua  appearance.lua  README.md ]
```

変更前（このブランチの親コミット）:

```
showtabline = 1
tabline     = (空)
MiniTabline = false
```

pty 上で実際に TUI を描画させ、最上行にバッファ一覧（`mini.icons` のファイルタイプ別アイコン付き）が表示されることも確認済みです。起動時エラーはありません。

なお Lua の lint / test はリポジトリに存在せず、CI（nixfmt・darwin build）は `*.nix` と `flake.lock` の変更時のみ発火するため、本変更では実行対象外です。