### PR TITLE
chore: mainの内容をfor-businessに取り込む（sandbox設定の削除）

### DIFF
--- a/home/claude/settings.json
+++ b/home/claude/settings.json
@@ -117,65 +117,6 @@
     }
   },
   "language": "日本語",
-  "sandbox": {
-    "enabled": true,
-    "autoAllowBashIfSandboxed": true,
-    "allowUnsandboxedCommands": false,
-    "network": {
-      "allowedDomains": [
-        "api.github.com"
-      ]
-    },
-    "filesystem": {
-      "allowWrite": [
-        "~/go/pkg/mod"
-      ],
-      "denyWrite": [
-        "~/.ssh",
-        "~/.aws",
-        "~/.config/gcloud",
-        "~/.kube",
-        "~/.gnupg",
-        "~/.netrc",
-        "~/.authinfo",
-        "~/Library/Keychains",
-        "~/Library/LaunchAgents",
-        "~/.zshrc",
-        "~/.zprofile",
-        "~/.bashrc",
-        "~/.bash_profile",
-        "/Users/yuuki/workspace/dotfiles/home/.zshrc",
-        "/Users/yuuki/workspace/dotfiles/home/.zprofile",
-        "/Users/yuuki/workspace/dotfiles/home/.gitconfig",
-        "/Users/yuuki/workspace/dotfiles/home/.codex"
-      ],
-      "denyRead": [
-        "~/.ssh",
-        "~/.aws",
-        "~/.config/gcloud",
-        "~/.kube",
-        "~/.gnupg",
-        "~/.netrc",
-        "~/.authinfo",
-        "~/.zsh_history",
-        "~/.bash_history",
-        "~/Library/Keychains",
-        "~/Library/Cookies",
-        "~/Library/Messages",
-        "~/Library/Mail",
-        "~/.codex",
-        "/Users/yuuki/workspace/dotfiles/home/.codex"
-      ],
-      "allowRead": []
-    },
-    "excludedCommands": [
-      "git",
-      "go",
-      "tinygo",
-      "mise",
-      "gh"
-    ]
-  },
   "effortLevel": "high",
   "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "latest",


### PR DESCRIPTION
## 概要

main の `chore(claude): sandbox 設定を削除` を for-business に取り込む。

## 変更内容

- `home/claude/settings.json` から `sandbox` ブロックを削除

for-business 固有の差分（Claude 通知 hooks の除外 / 3shake plugins など）はそのまま維持。

## 補足

- 反映には `make darwin-switch` が必要（`~/.claude/settings.json` は nix store への symlink のため）
- `autoAllowBashIfSandboxed` も無くなるため、Bash の permission プロンプトが再び出るようになる