### PR TITLE
feat(ocaml): opam switch をやめて dune の package management に移行する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOTFILES_DIR := $(CURDIR)
 
 export PATH := $(HOME)/.local/bin:$(PATH)
 
-.PHONY: setup submodule-init mise-install nix-install darwin-switch tools ocaml help
+.PHONY: setup submodule-init mise-install nix-install darwin-switch tools help
 
 setup: submodule-init mise-install nix-install darwin-switch tools ## Run full setup
 
@@ -36,11 +36,6 @@ darwin-switch: ## Apply nix-darwin + home-manager configuration (flake)
 tools: ## Install development tools (mise install, gopls)
 	mise install
 	mise exec -- go install golang.org/x/tools/gopls@latest
-
-ocaml: ## Bootstrap opam (init + default switch with ocamllsp/ocamlformat)
-	@command -v opam >/dev/null 2>&1 || { echo "opam not found. Run 'make darwin-switch' first."; exit 1; }
-	opam init --no-setup --yes
-	opam install --yes ocaml-lsp-server ocamlformat
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ make mise-install     # Install mise via curl (if not installed)
 make nix-install      # Install Nix via official installer (if not installed)
 make darwin-switch    # Apply nix-darwin + home-manager configuration (flake)
 make tools            # Install development tools (mise install, gopls)
-make ocaml            # Bootstrap opam (init, ocamllsp/ocamlformat)
 make help             # Show available targets
 ```
 

--- a/home/home.nix
+++ b/home/home.nix
@@ -24,6 +24,7 @@ in
   # The home.packages option allows you to install Nix packages into your
   # environment.
   home.packages = with pkgs; [
+    dune_3
     emmet-language-server
     fastfetch
     fzf
@@ -36,7 +37,6 @@ in
     neovim
     nixd
     nixfmt-rfc-style
-    opam
     ripgrep
     shfmt
     starship

--- a/home/nvim/lua/lsp/ocamllsp.lua
+++ b/home/nvim/lua/lsp/ocamllsp.lua
@@ -1,10 +1,7 @@
 local M = {}
 
--- ocamllsp は Nix でも mise でもなく dune の dev-tool として
--- `_build/.dev-tools.locks/` 以下に入るため PATH に直接は載らない。`dune tools exec` を
--- 挟むと、未インストールならその場で lock/build してから起動してくれる (初回はビルドを
--- 待たされる)。対象のワークスペースは dune がプロセスの cwd から辿って決めるので、
--- `nvim .` のようにプロジェクトルートで起動している前提。
+-- ocamllsp は dune の dev-tool として `_build/` 以下に入るため PATH に載らない。
+-- ワークスペースは cwd から解決されるので `nvim .` で開いている前提。
 M.cmd = { 'dune', 'tools', 'exec', 'ocamllsp' }
 
 -- .ml / .mli / .mll / .mly はすべて filetype 'ocaml'（Neovim の filetype.lua）。
@@ -24,9 +21,7 @@ M.settings = {
   merlinJumpCodeActions = { enable = true },
 }
 
--- フォーマットは ocamllsp が ocamlformat を PATH から探して呼ぶ。`dune tools exec` は
--- 全 dev-tool の bin ディレクトリを PATH に足してから exec するので、プロジェクトで
--- 一度 `dune tools install ocamlformat` しておけば <M-f> (vim.lsp.buf.format) が効く。
--- gopls の gofumpt / nixd の nixfmt と同じ扱い。
+-- <M-f> (vim.lsp.buf.format) は ocamllsp が PATH 上の ocamlformat を呼ぶ。dune tools exec
+-- が dev-tool の bin を PATH に足すため `dune tools install ocamlformat` 済みなら効く。
 
 return M

--- a/home/nvim/lua/lsp/ocamllsp.lua
+++ b/home/nvim/lua/lsp/ocamllsp.lua
@@ -1,9 +1,11 @@
 local M = {}
 
--- ocamllsp は Nix でも mise でもなく opam switch の中に入るため PATH に直接は載らない。
--- `opam exec --` を挟んで switch を解決してから起動する。switch はプロセスの cwd から
--- 決まるので、`nvim .` のようにプロジェクトルートで起動している前提。
-M.cmd = { 'opam', 'exec', '--', 'ocamllsp' }
+-- ocamllsp は Nix でも mise でもなく dune の dev-tool として
+-- `_build/.dev-tools.locks/` 以下に入るため PATH に直接は載らない。`dune tools exec` を
+-- 挟むと、未インストールならその場で lock/build してから起動してくれる (初回はビルドを
+-- 待たされる)。対象のワークスペースは dune がプロセスの cwd から辿って決めるので、
+-- `nvim .` のようにプロジェクトルートで起動している前提。
+M.cmd = { 'dune', 'tools', 'exec', 'ocamllsp' }
 
 -- .ml / .mli / .mll / .mly はすべて filetype 'ocaml'（Neovim の filetype.lua）。
 -- dune / dune-project / dune-workspace は filetype 'dune' で、ocamllsp が
@@ -22,7 +24,9 @@ M.settings = {
   merlinJumpCodeActions = { enable = true },
 }
 
--- フォーマットは ocamllsp が switch 内の ocamlformat を呼ぶため、<M-f>
--- (vim.lsp.buf.format) がそのまま効く。gopls の gofumpt / nixd の nixfmt と同じ扱い。
+-- フォーマットは ocamllsp が ocamlformat を PATH から探して呼ぶ。`dune tools exec` は
+-- 全 dev-tool の bin ディレクトリを PATH に足してから exec するので、プロジェクトで
+-- 一度 `dune tools install ocamlformat` しておけば <M-f> (vim.lsp.buf.format) が効く。
+-- gopls の gofumpt / nixd の nixfmt と同じ扱い。
 
 return M


### PR DESCRIPTION
## 概要

OCaml の依存解決とツールチェインを opam switch から dune 本体の package management に寄せる。

プロジェクト側で `dune-workspace` に `(pkg enabled)` を書けば `dune build` がコンパイラごと解決・ビルドするため、マシン単位で switch を bootstrap する手順が不要になる。

## 変更点

- `home/home.nix`: `opam` を外して `dune_3` を追加（pin している nixpkgs では 3.23.1）
- `Makefile` / `README.md`: グローバルな bootstrap が要らなくなったので `make ocaml`（`opam init` + `opam install ocaml-lsp-server ocamlformat`）を削除
- `home/nvim/lua/lsp/ocamllsp.lua`: 起動コマンドを `opam exec -- ocamllsp` から `dune tools exec ocamllsp` に変更

## 補足

- `dune tools exec` は未インストールなら lock/build してから起動するため、プロジェクトごとの初回起動はビルド待ちが発生する（dev-tool は `_build/.dev-tools.locks/` 配下にプロジェクト単位で入る）。
- ocamllsp は ocamlformat を PATH から探すが、`dune tools exec` は全 dev-tool の bin を PATH に足してから exec するので、プロジェクトで一度 `dune tools install ocamlformat` しておけば `<M-f>` のフォーマットが効く。
- `dune tools` は dune 側で experimental 扱いのため、将来コマンド体系が変わる可能性あり。

## 動作確認

- `make help`（`ocaml` ターゲットが消えていること）
- nixfmt / darwin build は CI に依存（このコンテナに nix が無いためローカル未実行）

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2n2ujDQwiMSKmCvj5Cyfp)_