### PR TITLE
chore(dependabot): 更新頻度を weekly から monthly に変更する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "nix" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` の nix ecosystem の `schedule.interval` を `weekly` から `monthly` に変更しました。

## 変更内容

```diff
 schedule:
-  interval: "weekly"
+  interval: "monthly"
```

Dependabot の PR が毎週ではなく月次で作成されるようになります。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAhM3uRpWG2TpuV4Tdxc56)_