### PR TITLE
chore(dependabot): github-actions と gitsubmodule を対象に追加する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## 概要

`.github/dependabot.yml` に `github-actions` と `gitsubmodule` の 2 エコシステムを追加する。

Closes #124

## 変更内容

- `github-actions` を追加。`.github/workflows/ci.yml` の `actions/checkout` と `DeterminateSystems/nix-installer-action` は SHA ピン + バージョンコメント付きなので、Dependabot が SHA とコメントの両方を更新する。
- `gitsubmodule` を追加。`.gitmodules` の `home/ghostty/shaders` が対象。
- 周期はどちらも既存の `nix` に揃えて `monthly`。#123 のマージ後の `main` から分岐している。

## 確認したこと

- `python3 -c "import yaml; yaml.safe_load(...)"` で YAML としてパースでき、3 エコシステムが読めることを確認した。
- `package.json` / `Cargo.toml` / `go.mod` / `Dockerfile` / `pyproject.toml` はリポジトリ内に存在しないため対象外のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvW9eS5Up8X1vcJZH4oA8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvW9eS5Up8X1vcJZH4oA8J)_