### PR TITLE
feat(claude): for-business にも通知フックを入れる

### DIFF
--- a/home/claude/hooks/notify.applescript
+++ b/home/claude/hooks/notify.applescript
@@ -1,0 +1,19 @@
+on run
+  try
+    do shell script "test -n \"${CC_INVOCATION-}\""
+  on error
+    return
+  end try
+  try
+    set b to do shell script "printf %s \"${CC_BODY-}\""
+  on error
+    set b to ""
+  end try
+  try
+    set t to do shell script "printf %s \"${CC_TITLE-}\""
+    if t is "" then set t to "Claude Code"
+  on error
+    set t to "Claude Code"
+  end try
+  display notification b with title t
+end run

--- a/home/claude/hooks/notify.sh
+++ b/home/claude/hooks/notify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload=$(cat)
+(
+  sleep 0.5
+  IFS=$'\x1f' read -r event message cwd transcript <<< "$(jq -r '[.hook_event_name // "", .message // "", .cwd // "", .transcript_path // ""] | join("")' <<< "$payload")"
+
+  if [[ $cwd == */*/* ]]; then
+    parent=${cwd%/*}
+    title="${parent##*/}/${cwd##*/}"
+  else
+    title=${cwd##*/}
+  fi
+  : "${title:=Claude Code}"
+
+  case "$event" in
+    Stop)
+      body=""
+      if [ -f "$transcript" ]; then
+        body=$(tail -n 500 "$transcript" | tail -r | jq -r '
+          select(.type=="assistant" and .message.role=="assistant")
+          | .message.content
+          | if type=="string" then . else (map(select(.type=="text") | .text) | join(" ")) end
+          | gsub("^\\s+|\\s+$"; "")
+          | select(length > 0)
+        ' 2>/dev/null | head -n 1 | tr '\n\r\t' '   ' | head -c 200 | { iconv -c -f UTF-8 -t UTF-8 2>/dev/null || true; })
+      fi
+      body=${body:-応答完了}
+      ;;
+    Notification) body=${message:-入力待ち} ;;
+    "") exit 0 ;;
+    *) body=${message:-$event} ;;
+  esac
+
+  LOG=~/.cache/claude-notify.log
+  [ -f "$LOG" ] && [ "$(stat -f%z "$LOG" 2>/dev/null || echo 0)" -gt 1048576 ] && rm -f "$LOG"
+  printf '[%s] ppid=%s event=%s title=%s\n' \
+    "$(date +%Y-%m-%dT%H:%M:%S)" "$PPID" "${event:-<empty>}" "$title" \
+    >> "$LOG" 2>/dev/null || true
+
+  APP=$HOME/Applications/ClaudeCodeNotifier.app
+  if [ -x "$APP/Contents/MacOS/applet" ]; then
+    CC_INVOCATION=1 CC_BODY=$body CC_TITLE=$title "$APP/Contents/MacOS/applet" >/dev/null 2>&1
+  fi
+) &
+disown

--- a/home/claude/settings.json
+++ b/home/claude/settings.json
@@ -74,10 +74,25 @@
   },
   "model": "sonnet",
   "hooks": {
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/notify.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",
         "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/notify.sh"
+          },
           {
             "type": "command",
             "command": "~/.claude/hooks/ai-tone-chat.sh"

--- a/home/home.nix
+++ b/home/home.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   pkgs,
   ...
 }:
@@ -96,6 +97,34 @@ in
   home.sessionVariables = {
     # EDITOR = "emacs";
   };
+
+  home.activation.claudeCodeNotifier = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    APP="$HOME/Applications/ClaudeCodeNotifier.app"
+    ICON="/Applications/Claude.app/Contents/Resources/electron.icns"
+    SRC="${dotfiles}/claude/hooks/notify.applescript"
+
+    if [ ! -f "$ICON" ] || [ ! -f "$SRC" ]; then
+      exit 0
+    fi
+
+    if [ -x "$APP/Contents/MacOS/applet" ] \
+       && [ ! "$SRC" -nt "$APP/Contents/MacOS/applet" ] \
+       && [ ! "$ICON" -nt "$APP/Contents/Resources/applet.icns" ]; then
+      exit 0
+    fi
+
+    mkdir -p "$HOME/Applications"
+    rm -rf "$APP"
+    /usr/bin/osacompile -o "$APP" "$SRC"
+    rm -f "$APP/Contents/Resources/Assets.car"
+    cp "$ICON" "$APP/Contents/Resources/applet.icns"
+    /usr/bin/plutil -replace CFBundleIdentifier -string "dev.yuuki.claude-code-notifier" "$APP/Contents/Info.plist"
+    /usr/bin/plutil -replace CFBundleName -string "Claude Code" "$APP/Contents/Info.plist"
+    /usr/bin/plutil -remove CFBundleIconName "$APP/Contents/Info.plist" 2>/dev/null || true
+    /usr/bin/codesign --sign - --force --deep "$APP" >/dev/null 2>&1 || true
+    /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f "$APP" >/dev/null 2>&1 || true
+    /usr/bin/touch "$APP"
+  '';
 
   programs.nh = {
     enable = true;


### PR DESCRIPTION
## 概要

`main` にはある Claude Code の macOS 通知まわりが `for-business` には入っていなかったので、同じ構成を移植する。作業機でも応答完了・入力待ちを通知で受け取れるようにするのが目的。

## 変更内容

- `home/claude/hooks/notify.sh` / `home/claude/hooks/notify.applescript` を追加（`main` と同一内容）
- `home/claude/settings.json`
  - `Notification` フックを新設し `notify.sh` を呼ぶ
  - `Stop` フックに `notify.sh` を追加（既存の `ai-tone-chat.sh` の前）
- `home/home.nix`
  - モジュール引数に `lib` を追加
  - `ClaudeCodeNotifier.app` を osacompile でビルドする `home.activation.claudeCodeNotifier` を追加（`main` と同一内容）

`.claude/hooks` の symlink は既に存在するため、そちらの変更は不要。

## 確認

- `bash -n home/claude/hooks/notify.sh` 通過
- `settings.json` の JSON パース確認済み
- `home.nix` の activation ブロックは `main` と diff なし（nixfmt 整形済みのものをそのまま挿入）
- 反映には `make darwin-switch` が必要（`home.file` ではなく activation 追加のため）

---
_Generated by [Claude Code](https://claude.ai/code/session_018KAnxEKw6JboAanfu2qi4H)_