### PR TITLE
feat(nvim): vim.pack のプラグインを月次で更新する workflow を追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
       - "flake.lock"
       - ".github/workflows/ci.yml"
 
+permissions: {}
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -16,8 +18,13 @@ jobs:
   lint:
     name: nixfmt
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read # checkout がリポジトリを読むため
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
@@ -28,8 +35,13 @@ jobs:
   build:
     name: build darwinConfiguration
     runs-on: macos-26
+    timeout-minutes: 60
+    permissions:
+      contents: read # checkout がリポジトリを読むため
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: read # checkout がリポジトリを読むため
+      contents: read # checkout のみ
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 60
     permissions:
-      contents: read # checkout がリポジトリを読むため
+      contents: read # checkout のみ
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/nvim-plugin-update.yml
+++ b/.github/workflows/nvim-plugin-update.yml
@@ -6,9 +6,7 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: nvim-plugin-update
@@ -18,8 +16,16 @@ jobs:
   update:
     name: vim.pack update
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write # create-pull-request が更新用ブランチを push するため
+      pull-requests: write # create-pull-request が PR を作成・更新するため
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # ブランチへの push と PR 作成は create-pull-request が token から
+          # 自前で認証を組み立てるため、checkout の資格情報は残さない
+          persist-credentials: false
 
       - name: Install Neovim
         uses: rhysd/action-setup-vim@febef33995d6649302e9d88dda81e071b68f16a7 # v1.6.1

--- a/.github/workflows/nvim-plugin-update.yml
+++ b/.github/workflows/nvim-plugin-update.yml
@@ -1,0 +1,61 @@
+name: Update Neovim plugins
+
+on:
+  schedule:
+    # 毎月 1 日 09:00 JST (00:00 UTC)。dependabot の monthly と揃えている
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: nvim-plugin-update
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: vim.pack update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@febef33995d6649302e9d88dda81e071b68f16a7 # v1.6.1
+        with:
+          neovim: true
+          version: stable
+
+      # vim.pack のロックファイルは $XDG_CONFIG_HOME/nvim/nvim-pack-lock.json に置かれる。
+      # リポジトリの home/ を設定ディレクトリの親として渡すことで、追跡済みの
+      # home/nvim/nvim-pack-lock.json がそのまま更新対象になる。
+      # プラグイン本体は "data" standard-path (~/.local/share/nvim) に入るため
+      # ワークスペースにはロックファイル以外の差分が出ない。
+      - name: Update plugins
+        env:
+          XDG_CONFIG_HOME: ${{ github.workspace }}/home
+        # -u NONE で init.lua は読み込まない。ロックファイルにあるプラグインは
+        # 最初の vim.pack 呼び出しでロックファイルのリビジョンのまま入るので、
+        # LSP や treesitter パーサーを用意せずに更新だけを実行できる。
+        # headless の Neovim は Lua のエラーでも終了コード 0 になるため、
+        # pcall で捕まえて :cquit で失敗を伝える。
+        run: |
+          nvim --headless -u NONE -c 'lua local ok, err = pcall(vim.pack.update, nil, { force = true }); if not ok then io.stderr:write(tostring(err) .. "\n") end; vim.cmd(ok and "qall" or "cquit")'
+
+      # 差分がなければ PR は作られない (自動マージもしない)
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          add-paths: home/nvim/nvim-pack-lock.json
+          branch: chore/nvim-plugin-update
+          delete-branch: true
+          commit-message: "chore(nvim): vim.pack のプラグインを更新する"
+          title: "chore(nvim): vim.pack のプラグインを更新する"
+          body: |
+            `vim.pack.update()` によるプラグインの月次更新です。
+
+            - 更新対象は `home/nvim/nvim-pack-lock.json` のみです
+            - 取り込んだあと、手元では `:restart` で新しいリビジョンが読み込まれます
+            - 個別に戻したい場合は、該当プラグインの `rev` を元に戻して
+              `vim.pack.update({ 'plugin' }, { offline = true, target = 'lockfile' })` を実行してください

--- a/.github/workflows/nvim-plugin-update.yml
+++ b/.github/workflows/nvim-plugin-update.yml
@@ -17,12 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: write # ブランチの push
-      pull-requests: write # PR の作成・更新
+      contents: write # push
+      pull-requests: write # PR
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # push の認証は create-pull-request が token から自前で組み立てる
           persist-credentials: false
 
       - name: Install Neovim
@@ -33,10 +32,8 @@ jobs:
 
       - name: Update plugins
         env:
-          # lockfile は $XDG_CONFIG_HOME/nvim/nvim-pack-lock.json に置かれる
-          XDG_CONFIG_HOME: ${{ github.workspace }}/home
-        # lockfile のプラグインは -u NONE でも入るため init.lua は読まない。
-        # headless は Lua エラーでも exit 0 になるので :cquit で失敗を伝える。
+          XDG_CONFIG_HOME: ${{ github.workspace }}/home # lockfile は nvim/ の下
+        # init.lua は読まない。Lua エラーでも exit 0 なので :cquit で返す
         run: |
           nvim --headless -u NONE -c 'lua local ok, err = pcall(vim.pack.update, nil, { force = true }); if not ok then io.stderr:write(tostring(err) .. "\n") end; vim.cmd(ok and "qall" or "cquit")'
 

--- a/.github/workflows/nvim-plugin-update.yml
+++ b/.github/workflows/nvim-plugin-update.yml
@@ -2,8 +2,7 @@ name: Update Neovim plugins
 
 on:
   schedule:
-    # 毎月 1 日 09:00 JST (00:00 UTC)。dependabot の monthly と揃えている
-    - cron: "0 0 1 * *"
+    - cron: "0 0 1 * *" # 毎月 1 日 09:00 JST
   workflow_dispatch:
 
 permissions: {}
@@ -18,13 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: write # create-pull-request が更新用ブランチを push するため
-      pull-requests: write # create-pull-request が PR を作成・更新するため
+      contents: write # ブランチの push
+      pull-requests: write # PR の作成・更新
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # ブランチへの push と PR 作成は create-pull-request が token から
-          # 自前で認証を組み立てるため、checkout の資格情報は残さない
+          # push の認証は create-pull-request が token から自前で組み立てる
           persist-credentials: false
 
       - name: Install Neovim
@@ -33,23 +31,15 @@ jobs:
           neovim: true
           version: stable
 
-      # vim.pack のロックファイルは $XDG_CONFIG_HOME/nvim/nvim-pack-lock.json に置かれる。
-      # リポジトリの home/ を設定ディレクトリの親として渡すことで、追跡済みの
-      # home/nvim/nvim-pack-lock.json がそのまま更新対象になる。
-      # プラグイン本体は "data" standard-path (~/.local/share/nvim) に入るため
-      # ワークスペースにはロックファイル以外の差分が出ない。
       - name: Update plugins
         env:
+          # lockfile は $XDG_CONFIG_HOME/nvim/nvim-pack-lock.json に置かれる
           XDG_CONFIG_HOME: ${{ github.workspace }}/home
-        # -u NONE で init.lua は読み込まない。ロックファイルにあるプラグインは
-        # 最初の vim.pack 呼び出しでロックファイルのリビジョンのまま入るので、
-        # LSP や treesitter パーサーを用意せずに更新だけを実行できる。
-        # headless の Neovim は Lua のエラーでも終了コード 0 になるため、
-        # pcall で捕まえて :cquit で失敗を伝える。
+        # lockfile のプラグインは -u NONE でも入るため init.lua は読まない。
+        # headless は Lua エラーでも exit 0 になるので :cquit で失敗を伝える。
         run: |
           nvim --headless -u NONE -c 'lua local ok, err = pcall(vim.pack.update, nil, { force = true }); if not ok then io.stderr:write(tostring(err) .. "\n") end; vim.cmd(ok and "qall" or "cquit")'
 
-      # 差分がなければ PR は作られない (自動マージもしない)
       - name: Create pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -59,9 +49,4 @@ jobs:
           commit-message: "chore(nvim): vim.pack のプラグインを更新する"
           title: "chore(nvim): vim.pack のプラグインを更新する"
           body: |
-            `vim.pack.update()` によるプラグインの月次更新です。
-
-            - 更新対象は `home/nvim/nvim-pack-lock.json` のみです
-            - 取り込んだあと、手元では `:restart` で新しいリビジョンが読み込まれます
-            - 個別に戻したい場合は、該当プラグインの `rev` を元に戻して
-              `vim.pack.update({ 'plugin' }, { offline = true, target = 'lockfile' })` を実行してください
+            `vim.pack.update()` による月次更新です。取り込んだあとは `:restart` で反映されます。

--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ make help             # Show available targets
   - `darwin/` 配下 (`configuration.nix` / `homebrew.nix` など) の変更
   - `flake.nix` / `flake.lock` の更新
 - `flake.lock` を更新する場合は `nix flake update` 後に `make darwin-switch`。
+- Neovim のプラグインは `vim.pack` 管理で、リビジョンは `home/nvim/nvim-pack-lock.json` に記録される。GitHub Actions の `Update Neovim plugins` が毎月 1 日に `vim.pack.update()` を実行し、lockfile に差分があるときだけ PR を作る（手動実行は Actions タブの workflow_dispatch から）。取り込んだあとは `:restart` で新しいリビジョンが読み込まれる。


### PR DESCRIPTION
## 概要

headless の Neovim から `vim.pack.update()` を実行して、`home/nvim/nvim-pack-lock.json` を月次で更新する workflow を追加しました。既存の `vim.pack.add()` ベースの構成はそのままで、プラグインマネージャーの追加もしていません。

あわせて、`actionlint` / `ghalint` / `zizmor` の指摘を両 workflow で解消しています。

## 追加したもの

- `.github/workflows/nvim-plugin-update.yml`
  - `schedule` (毎月 1 日 00:00 UTC / 09:00 JST) と `workflow_dispatch` で起動
  - `rhysd/action-setup-vim` で Neovim stable を入れて `vim.pack.update(nil, { force = true })` を実行
  - lockfile に差分が出たときだけ `peter-evans/create-pull-request` で PR を作成（自動マージはしない）
- `README.md` に 1 行だけ説明を追記

## lockfile の扱い

`vim.pack` の lockfile は `$XDG_CONFIG_HOME/nvim/nvim-pack-lock.json` に置かれます。このリポジトリでは `home/nvim` が `~/.config/nvim` に symlink されているため、workflow では `XDG_CONFIG_HOME` にチェックアウト先の `home/` を渡しています。これで追跡済みの `home/nvim/nvim-pack-lock.json` がそのまま更新対象になります。プラグイン本体は "data" standard-path (`~/.local/share/nvim`) に入るので、ワークスペースには lockfile 以外の差分が出ません。

`init.lua` は `-u NONE` で読み込んでいません。lockfile にあるプラグインは最初の `vim.pack` 呼び出しでそのリビジョンのままインストールされるため、LSP サーバーや treesitter パーサーを用意しなくても更新だけを実行できます。

headless の Neovim は Lua がエラーになっても終了コード 0 で終わるため、`pcall` で捕まえて `:cquit` で失敗を伝えるようにしています。

## Lint 対応

`actionlint` は最初から指摘ゼロでした。`ghalint` と `zizmor` の指摘を両 workflow で解消しています。

| 指摘 | 対応 |
|---|---|
| ghalint 001 / zizmor `excessive-permissions` | 既定の `permissions` を空にして、必要な権限を job 単位で持たせる |
| ghalint 012 | 各 job に `timeout-minutes` を設定する |
| ghalint 013 / zizmor `artipacked` | `checkout` の `persist-credentials` を `false` にする |
| zizmor `undocumented-permissions` | `permissions` の各行に理由を行末コメントで書く |

`nvim-plugin-update.yml` では push と PR 作成を `create-pull-request` が `token` から自前で認証を組み立てるため、`persist-credentials: false` でも動きます（`git-config-helper.ts` の `configureToken` が常に extraheader を設定します）。`ci.yml` は push をしないので同様に不要です。

`zizmor --persona=auditor` では `superfluous-actions`（`gh pr create` を使ってはどうか）が info レベルで残ります。`create-pull-request` は「差分が無ければ PR を作らない」「ブランチを使い回す」を自前のスクリプト無しで賄えるため、そのまま採用しています。

## 検証

**Lint** — `actionlint` / `ghalint run` / `ghalint run-action` / `zizmor`（既定 persona）のいずれも、リポジトリ全体で指摘ゼロです。

**動作** — Neovim v0.12.5 を使い、リポジトリのクローンに対して workflow と同じコマンドを実行して確認しました。

- 更新コマンドが成功すること: fresh な `$HOME` + このリポジトリのクローンで exit 0
- lockfile が正しく更新されること: `marp.nvim` / `mini.nvim` / `nvim-treesitter` / `vimdoc-ja` の 4 件の `rev` が更新され、変更ファイルは `home/nvim/nvim-pack-lock.json` のみ
- 更新がない場合に差分が出ないこと: lockfile が最新の状態で fresh な runner から再実行 → `git status` は空（PR は作られない）
- 通常の headless 起動が壊れていないこと: 更新後のプラグインで `nvim --headless` が exit 0、`vim.pack.get()` が 9 件を返し、起動によって lockfile が書き換わらないことも確認

## 補足

`peter-evans/create-pull-request` が `GITHUB_TOKEN` で PR を作るには、リポジトリ設定の Settings → Actions → General → Workflow permissions にある **Allow GitHub Actions to create and approve pull requests** が有効になっている必要があります。

`ci.yml` の `actions/checkout` は v7.0.0 のままにしてあります（v7.0.1 が出ていますが、dependabot の github-actions 月次更新で上がる想定です）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yX7zYDN9CBFCHeAoPWpSt