### PR TITLE
refactor(nix): nixfmt-rfc-style を nixfmt に置き換える

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Check formatting
-        run: nix run nixpkgs#nixfmt-rfc-style -- --check $(git ls-files '*.nix')
+        run: nix run nixpkgs#nixfmt -- --check $(git ls-files '*.nix')
 
   build:
     name: build darwinConfiguration

--- a/home/home.nix
+++ b/home/home.nix
@@ -36,7 +36,7 @@ in
     lua-language-server
     neovim
     nixd
-    nixfmt-rfc-style
+    nixfmt
     ripgrep
     shfmt
     starship


### PR DESCRIPTION
## 概要

`nixfmt-rfc-style` の評価時に次の警告が出るようになったため、参照を `nixfmt` に置き換えます。

```
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
```

## 変更内容

- `home/home.nix`: `home.packages` の `nixfmt-rfc-style` を `nixfmt` に変更（アルファベット順は維持）
- `.github/workflows/ci.yml`: フォーマットチェックを `nix run nixpkgs#nixfmt -- --check` に変更

`home/nvim/after/lsp/nixd.lua` のフォーマッタ設定は元から `nixfmt` を呼び出しているため変更していません。

## 動作確認

この環境には Nix が入っていないためローカルでの評価・ビルドは実施できていません。CI の nixfmt ジョブと darwinConfiguration ビルドでの確認をお願いいたします。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BP4w147PAemJMLPtZmES9Q


---
_Generated by [Claude Code](https://claude.ai/code/session_01BP4w147PAemJMLPtZmES9Q)_